### PR TITLE
feat: production deployment — Hugging Face Spaces backend + CI/CD cleanup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+frontend/node_modules
+frontend/build
+backend/chroma_db
+backend/__pycache__
+backend/**/__pycache__
+backend/.pytest_cache
+backend/tests
+*.env
+.env*
+.git
+.github

--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,9 @@
 # Required — get your key at https://console.anthropic.com
 ANTHROPIC_API_KEY=sk-ant-...
 
+# Claude model used by both agents (defaults to claude-sonnet-4-6)
+ANTHROPIC_MODEL=claude-sonnet-4-6
+
 # Port the backend listens on (7860 = HF Spaces default; 5000 = local dev)
 PORT=5000
 

--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,19 @@
 # Copy to .env and fill in your values
+
+# Required — get your key at https://console.anthropic.com
 ANTHROPIC_API_KEY=sk-ant-...
-FLASK_ENV=development
+
+# Port the backend listens on (7860 = HF Spaces default; 5000 = local dev)
+PORT=5000
+
+# Where ChromaDB persists its vector index
 CHROMA_PERSIST_DIR=./backend/chroma_db
+
+# Flask environment (set to 'production' in deployed environments)
+FLASK_ENV=development
+
+# Comma-separated list of allowed CORS origins
+CORS_ORIGINS=http://localhost:3000,https://ksek87.github.io
+
+# Frontend: URL of the backend API (used at React build time)
+REACT_APP_API_URL=http://localhost:5000

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Deploy to GitHub Pages
 on:
   push:
     branches:
-      - main 
+      - main
 
 jobs:
   deploy:
@@ -11,37 +11,28 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
-          node-version: '16'
+          node-version: '18'
           cache: 'npm'
           cache-dependency-path: frontend/package-lock.json
 
       - name: Install dependencies
-        run: |
-          cd frontend
-          echo '{ "homepage": "https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}" }' >> package.json
-          npm install
-          npm install react@18 react-dom@18
-
-          npm install --save-dev typescript @types/react @types/react-dom @types/node @babel/plugin-proposal-private-property-in-object
-
+        run: cd frontend && npm ci --legacy-peer-deps
 
       - name: Type check
-        run: |
-          cd frontend
-          npx tsc --noEmit
+        run: cd frontend && npx tsc --noEmit
 
-      - name: Build the app
+      - name: Build
         env:
+          # Set BACKEND_URL as a GitHub Actions secret pointing to your deployed backend
+          # (e.g. https://ksek87-sniff-ai.hf.space). Falls back to localhost for local dev.
+          REACT_APP_API_URL: ${{ secrets.BACKEND_URL }}
           PUBLIC_URL: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}
-          REACT_APP_BASE_PATH: /${{ github.event.repository.name }}
-        run: |
-          cd frontend
-          CI=false npm run build
+        run: cd frontend && CI=false npm run build
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,7 +25,8 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Build backend image
-      run: docker build -t sniff-ai-backend ./backend
+      # Build context is repo root so the Dockerfile can COPY data_collection/dataset.csv
+      run: docker build -f backend/Dockerfile -t sniff-ai-backend .
 
     - name: Build frontend image
       run: docker build -t sniff-ai-frontend ./frontend

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,33 +1,56 @@
-name: Pylint
+name: CI
 
 on: [push]
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.11"]
+
     steps:
     - uses: actions/checkout@v4
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+        cache: 'pip'
+        cache-dependency-path: |
+          requirements.txt
+          backend/requirements.txt
 
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
         pip install -r backend/requirements.txt
+        pip install pylint
 
-    - name: Install pylint
-      run: pip install pylint
+    - name: Install spaCy model
+      run: python -m spacy download en_core_web_sm
 
-    - name: Analyse the code with pylint
+    - name: Lint (errors only)
       env:
         PYTHONPATH: backend
       run: |
         pylint --errors-only --disable=E1101 \
                $(git ls-files '*.py')
+
+    - name: Run tests
+      env:
+        PYTHONPATH: backend
+        ANTHROPIC_API_KEY: test-key-not-used
+      run: |
+        pytest --tb=short -q \
+               --cov=backend \
+               --cov-report=term-missing \
+               --cov-report=xml:coverage.xml
+
+    - name: Upload coverage report
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: coverage-report
+        path: coverage.xml

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,12 @@ __pycache__/
 model/notebooks/results/
 model/notebooks/trained_model/
 
+# Generated runtime artifacts
+backend/data/*.pkl
+backend/data/feedback.db
+backend/chroma_db/
+chroma_db/
+
 # Logs
 *.log
 

--- a/README.md
+++ b/README.md
@@ -1,100 +1,162 @@
 # Sniff AI
 
-Sniff AI is an AI-powered fragrance creation platform that translates poetic and descriptive text into custom fragrance compositions. This project combines generative AI with a curated fragrance database to inspire and generate scent profiles, showcasing both Product Management and AI/ML engineering capabilities.
+Sniff AI translates poetic, descriptive language ("a thunderstorm over a pine forest at dusk") into professional fragrance compositions — complete with a structured notes pyramid (top / middle / base), percentage breakdowns, a custom name, and real-world reference fragrances.
+
+Live frontend: **[ksek87.github.io/sniff_ai](https://ksek87.github.io/sniff_ai/)**
 
 ---
 
-## Table of Contents
+## How It Works
 
-- [Project Overview](#project-overview)
-- [Key Features](#key-features)
-- [Tech Stack](#tech-stack)
-- [Project Phases & Progress](#project-phases--progress)
-- [Installation](#installation)
-- [Usage](#usage)
-- [Future Enhancements](#future-enhancements)
+```
+User description
+  → NLP preprocessing (spaCy note detection, sklearn scent-family classifier)
+  → ChromaDB semantic search (sentence-transformers all-MiniLM-L6-v2)
+  → Orchestrator Agent (Claude claude-sonnet-4-6, tool use)
+  → Composition Agent (Claude claude-sonnet-4-6, structured JSON output)
+  → Fragrance Card (React frontend)
+```
 
----
-
-## Project Overview
-
-Sniff AI generates custom fragrance compositions based on user-provided descriptions, ranging from simple phrases to poetic imagery. The platform leverages a dataset of existing fragrances for model training and reference, creating unique blends that align with user input.
-
-### Check out my Product Management documentation (roadmaps, features, etc) in [product-management](https://github.com/ksek87/sniff_ai/tree/main/product-management)
-
-### Analysis of Fragrances Dataset can be found [here](https://github.com/ksek87/sniff_ai/blob/dev/model/notebooks/dataset-analysis.ipynb)
----
-
-## Key Features
-
-- **Text-to-Fragrance Generation**: Transform descriptive language into a unique fragrance profile.
-- **Fragrance Database**: Access to a searchable database of existing fragrances with detailed fragrance notes, scent families, and additional information.
-- **Customizable Interface**: User-friendly UI for inputting descriptions, selecting preferred notes, and viewing generated fragrance compositions.
-- **Feedback System**: A mechanism for users to rate generated fragrances, aiding in model refinement.
+The system uses **two Claude API calls** per generation. No local LLM is run. The NLP layer (spaCy + sklearn + sentence-transformers) runs entirely on CPU and adds ~50ms.
 
 ---
 
 ## Tech Stack
 
-- **Backend**: Python, Flask or Django
-- **Frontend**: React or Vue.js
-- **Database**: PostgreSQL with Elasticsearch for fast search
-- **Modeling**: Generative AI (e.g., GPT or custom transformer models) and NLP
+| Layer | Technology |
+|-------|-----------|
+| LLM reasoning | Anthropic Claude claude-sonnet-4-6 (API) |
+| Vector search | ChromaDB (embedded, cosine similarity) |
+| Embeddings | sentence-transformers `all-MiniLM-L6-v2` |
+| NER | spaCy `EntityRuler` (rule-based, no training) |
+| Scent classifier | scikit-learn TF-IDF + Logistic Regression |
+| Backend | Python 3.11, Flask, gunicorn |
+| Frontend | React 18, TypeScript 5, Axios |
+| Frontend hosting | GitHub Pages |
+| Backend hosting | Hugging Face Spaces (Docker, free tier) |
 
 ---
 
-## Project Phases & Progress
+## Architecture
 
-### Phase 1: Research and Data Collection
-- [x] **Gather fragrance data** from online databases and public sources
-- [x] **Curate dataset** of fragrance notes, descriptions, and scent concepts
-- [x] **Compile paired data** of poetic descriptions and fragrance compositions for initial training
+### Backend API (`/api/v1/`)
 
-**Dataset** was built in this project [Fragrances](https://github.com/ksek87/fragrances)
+| Endpoint | Method | Purpose |
+|----------|--------|---------|
+| `/generate` | POST | Generate fragrance from description |
+| `/feedback` | POST | Submit 1–5 star rating |
+| `/search` | GET | Semantic search over fragrance database |
+| `/notes` | GET | List all available fragrance notes |
+| `/families` | GET | List scent families |
+| `/metrics` | GET | Aggregated feedback metrics |
+| `/health` | GET | Health check |
 
-### Phase 2: Initial Model Development
-- [ ] **Fine-tune language model** (GPT, BERT, or similar) on paired text-fragrance data
-- [ ] **Train fragrance composition model** to create blends from semantic interpretations of descriptions
-- [ ] **Evaluate model outputs** to ensure relevance and accuracy using similarity scores
+### Output Schema
 
-### Phase 3: Building the Database
-- [ ] **Set up relational database** (PostgreSQL) for storing fragrance data
-- [ ] **Integrate Elasticsearch** for efficient fragrance search
-- [ ] **Populate database** with curated fragrance data
-
-### Phase 4: User Interface and Experience
-- [ ] **Design user interface** mockups for text input and fragrance output display
-- [ ] **Implement frontend** in React or Vue.js
-- [ ] **Integrate model with UI** for real-time or asynchronous fragrance generation
-
-### Phase 5: Model Refinement
-- [ ] **Establish user feedback loops** allowing users to rate or tweak generated fragrances
-- [ ] **Integrate feedback mechanism** to refine model outputs based on user interactions
-- [ ] **Iterate on model improvements** based on feedback and testing
-
----
-
-## Installation
-
-*Instructions for setting up the project locally will go here.*
+```json
+{
+  "name": "Twilight Pine Accord",
+  "scent_family": "Woody Aromatic",
+  "top_notes":    [{"note": "Bergamot",    "percentage": 15}],
+  "middle_notes": [{"note": "Pine Needle", "percentage": 25}],
+  "base_notes":   [{"note": "Cedarwood",   "percentage": 35}],
+  "poetic_description": "…",
+  "similar_fragrances": [{"brand": "Jo Malone", "name": "Wood Sage & Sea Salt", "similarity_score": 0.87}],
+  "confidence_score": 0.91
+}
+```
 
 ---
 
-## Usage
+## Running Locally
 
-*Instructions for using Sniff AI will go here, including how to input descriptions, select fragrance notes, and view outputs.*
+### Prerequisites
+- Python 3.11+
+- Node 18+
+- An `ANTHROPIC_API_KEY` (get one at [console.anthropic.com](https://console.anthropic.com))
+
+### Backend
+
+```bash
+cd backend
+pip install -r requirements.txt
+
+# One-time: populate ChromaDB and generate note_profiles.json (~8 min)
+python scripts/ingest_dataset.py
+
+# Start the API server
+ANTHROPIC_API_KEY=sk-ant-... python app.py
+# → http://localhost:7860
+```
+
+### Frontend
+
+```bash
+cd frontend
+npm install --legacy-peer-deps
+REACT_APP_API_URL=http://localhost:7860 npm start
+# → http://localhost:3000
+```
+
+### Docker Compose (recommended for local dev)
+
+```bash
+cp .env.example .env          # add your ANTHROPIC_API_KEY
+docker compose up --build
+```
+
+Backend at `localhost:5000`, frontend at `localhost:3000`.  
+The backend runs `start.sh` which auto-populates ChromaDB on first start (~8 min), then starts gunicorn.
 
 ---
 
-## Future Enhancements
+## Deployment
 
-- [ ] **Additional Input Customization**: Allow users to select fragrance intensity, season, or occasion.
-- [ ] **Improved Fragrance Matching**: Refine similarity scoring for more precise fragrance outputs.
-- [ ] **User Accounts and Saved Fragrances**: Enable users to save generated compositions to their profiles.
+### Backend — Hugging Face Spaces
+
+1. Create a new Space (Docker SDK, public) at [huggingface.co/spaces](https://huggingface.co/spaces)
+2. Set Space secrets: `ANTHROPIC_API_KEY`, `CHROMA_PERSIST_DIR=/data/chroma_db`
+3. Deploy the GHCR image: `ghcr.io/ksek87/sniff_ai/backend:latest`
+4. First startup ingests the dataset (~8 min); ChromaDB persists at `/data/chroma_db`
+
+### Frontend — GitHub Pages
+
+The `deploy.yml` workflow builds and deploys automatically on every push to `main`.
+
+Set the GitHub Actions secret `BACKEND_URL` to your HF Space URL (e.g. `https://ksek87-sniff-ai.hf.space`) so the frontend build wires up the correct API endpoint.
+
+```
+Repo Settings → Secrets and variables → Actions → New repository secret
+Name: BACKEND_URL
+Value: https://your-space-name.hf.space
+```
 
 ---
 
-Feel free to contribute, suggest features, or reach out with feedback. This project is in progress, and any input is appreciated!
+## Data
+
+The fragrance database (`data_collection/dataset.csv`) contains **13,644 records** scraped from public fragrance catalogues, with fields: Brand, Name, Description, Notes (list), Concepts (list).
+
+One-time ingestion via `scripts/ingest_dataset.py`:
+- Encodes all records with `all-MiniLM-L6-v2` (384-dim vectors)
+- Stores in ChromaDB with cosine HNSW index
+- Generates `backend/data/note_profiles.json` (volatility + co-occurrence pairs for 1,000+ notes)
 
 ---
 
+## Project Phases
+
+- [x] **Phase 1** — Data collection & curation (13,644 fragrance records)
+- [x] **Phase 2** — Agentic pipeline (Claude API + ChromaDB + NLP layer)
+- [x] **Phase 3** — React frontend (Fragrance Card, Notes Pyramid, feedback)
+- [ ] **Phase 4** — Personalization (pinned notes, scent family filter)
+- [ ] **Phase 5** — Search panel + metrics dashboard
+- [ ] **Phase 6** — Feedback loop (re-weight classifier on ratings)
+
+---
+
+## Contributing
+
+PRs welcome. For larger changes, open an issue first to discuss the approach.
+
+Product management documentation (roadmaps, feature specs): [`/product-management`](product-management/)

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,17 +1,22 @@
 FROM python:3.11-slim
 
-WORKDIR /usr/src/app
+WORKDIR /app
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    build-essential \
-    cmake \
+    build-essential cmake curl \
     && rm -rf /var/lib/apt/lists/*
 
-COPY requirements.txt ./
+COPY backend/requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY . .
+COPY backend/ ./
 
-EXPOSE 5000
+# Dataset lands at /data_collection/dataset.csv — matches the relative path
+# computed by ingest_dataset.py (scripts/../../data_collection/dataset.csv)
+COPY data_collection/dataset.csv /data_collection/dataset.csv
 
-CMD ["python", "app.py"]
+RUN chmod +x start.sh
+
+EXPOSE 7860
+
+CMD ["./start.sh"]

--- a/backend/api/routes.py
+++ b/backend/api/routes.py
@@ -65,12 +65,11 @@ def feedback():
 @limiter.limit("30 per hour")
 def search():
     query = _sanitize(request.args.get("q", ""))
-    family = request.args.get("family")
     if not query:
         return jsonify({"error": "q parameter is required"}), 400
     if len(query) > _MAX_DESCRIPTION:
         return jsonify({"error": f"q must be {_MAX_DESCRIPTION} characters or fewer"}), 400
-    results = search_fragrance_db(query, scent_family=family, top_k=10)
+    results = search_fragrance_db(query, top_k=10)
     return jsonify(results)
 
 

--- a/backend/api/routes.py
+++ b/backend/api/routes.py
@@ -1,20 +1,42 @@
+import re
 from flask import Blueprint, request, jsonify
 from services.generate_fragrance import generate_fragrance_from_description
 from services.feedback import save_feedback, get_metrics
 from services.tools.search_tool import search_fragrance_db
 from services.nlp import get_all_notes, get_all_families
+from limiter import limiter
 
 api_blueprint = Blueprint("api", __name__)
 
+_MAX_DESCRIPTION = 500
+_MAX_NOTE_LEN = 100
+_MAX_PINNED_NOTES = 10
+# Strip ASCII control characters (keep printable + normal whitespace)
+_CONTROL_RE = re.compile(r"[\x00-\x08\x0b-\x1f\x7f]")
+
+
+def _sanitize(text: str) -> str:
+    return _CONTROL_RE.sub("", text).strip()
+
 
 @api_blueprint.route("/generate", methods=["POST"])
+@limiter.limit("5 per hour")
 def generate():
     data = request.get_json(silent=True) or {}
-    description = data.get("description", "").strip()
+
+    description = _sanitize(str(data.get("description", "")))
     if not description:
         return jsonify({"error": "description is required"}), 400
+    if len(description) > _MAX_DESCRIPTION:
+        return jsonify({"error": f"description must be {_MAX_DESCRIPTION} characters or fewer"}), 400
 
-    pinned_notes = data.get("pinned_notes", [])
+    raw_notes = data.get("pinned_notes", [])
+    if not isinstance(raw_notes, list):
+        return jsonify({"error": "pinned_notes must be an array"}), 400
+    if len(raw_notes) > _MAX_PINNED_NOTES:
+        return jsonify({"error": f"pinned_notes may contain at most {_MAX_PINNED_NOTES} items"}), 400
+    pinned_notes = [_sanitize(str(n))[:_MAX_NOTE_LEN] for n in raw_notes if str(n).strip()]
+
     result = generate_fragrance_from_description(description, pinned_notes)
     return jsonify(result)
 
@@ -40,11 +62,14 @@ def feedback():
 
 
 @api_blueprint.route("/search", methods=["GET"])
+@limiter.limit("30 per hour")
 def search():
-    query = request.args.get("q", "").strip()
+    query = _sanitize(request.args.get("q", ""))
     family = request.args.get("family")
     if not query:
         return jsonify({"error": "q parameter is required"}), 400
+    if len(query) > _MAX_DESCRIPTION:
+        return jsonify({"error": f"q must be {_MAX_DESCRIPTION} characters or fewer"}), 400
     results = search_fragrance_db(query, scent_family=family, top_k=10)
     return jsonify(results)
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,3 +1,4 @@
+import os
 from flask import Flask, jsonify
 from flask_cors import CORS
 from dotenv import load_dotenv
@@ -6,7 +7,13 @@ from api.routes import api_blueprint
 load_dotenv()
 
 app = Flask(__name__)
-CORS(app, origins=["http://localhost:3000", "https://ksek87.github.io"])
+
+_origins = os.getenv(
+    "CORS_ORIGINS",
+    "http://localhost:3000,https://ksek87.github.io",
+).split(",")
+CORS(app, origins=[o.strip() for o in _origins])
+
 app.register_blueprint(api_blueprint, url_prefix="/api/v1")
 
 
@@ -16,4 +23,4 @@ def health():
 
 
 if __name__ == "__main__":
-    app.run(host="0.0.0.0", port=5000, debug=True)
+    app.run(host="0.0.0.0", port=int(os.getenv("PORT", 7860)))

--- a/backend/app.py
+++ b/backend/app.py
@@ -3,6 +3,7 @@ from flask import Flask, jsonify
 from flask_cors import CORS
 from dotenv import load_dotenv
 from api.routes import api_blueprint
+from limiter import limiter
 
 load_dotenv()
 
@@ -14,6 +15,7 @@ _origins = os.getenv(
 ).split(",")
 CORS(app, origins=[o.strip() for o in _origins])
 
+limiter.init_app(app)
 app.register_blueprint(api_blueprint, url_prefix="/api/v1")
 
 

--- a/backend/limiter.py
+++ b/backend/limiter.py
@@ -1,0 +1,11 @@
+from flask_limiter import Limiter
+from flask_limiter.util import get_remote_address
+
+# Shared limiter instance — init_app(app) called in app.py.
+# storage_uri="memory://" is per-process; acceptable for a single-server
+# demo. Swap for "redis://..." if you ever run multiple replicas.
+limiter = Limiter(
+    key_func=get_remote_address,
+    storage_uri="memory://",
+    default_limits=[],
+)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,4 +12,5 @@ numpy>=2.0.2
 requests>=2.32.3
 Werkzeug>=3.1.2
 pytest>=7.0.0
+flask-limiter>=3.0.0
 gunicorn>=21.0.0

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,7 +9,6 @@ python-dotenv>=1.0.0
 SQLAlchemy>=2.0.36
 pandas>=2.2.3
 numpy>=2.0.2
-requests>=2.32.3
 Werkzeug>=3.1.2
 pytest>=7.0.0
 flask-limiter>=3.0.0

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -11,5 +11,6 @@ pandas>=2.2.3
 numpy>=2.0.2
 Werkzeug>=3.1.2
 pytest>=7.0.0
+pytest-cov>=4.0.0
 flask-limiter>=3.0.0
 gunicorn>=21.0.0

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,3 +12,4 @@ numpy>=2.0.2
 requests>=2.32.3
 Werkzeug>=3.1.2
 pytest>=7.0.0
+gunicorn>=21.0.0

--- a/backend/services/agents/composer.py
+++ b/backend/services/agents/composer.py
@@ -4,10 +4,13 @@ the final structured FragranceComposition JSON.
 """
 from __future__ import annotations
 import json
+import logging
 import os
 import re
 
 import anthropic
+
+logger = logging.getLogger(__name__)
 
 _MODEL = "claude-sonnet-4-6"
 
@@ -69,10 +72,10 @@ def run(description: str, orchestrator_result: dict) -> dict:
 
     try:
         composition = json.loads(raw)
-        # Normalise percentages to sum to 100 if slightly off
         _normalise_percentages(composition)
         return composition
-    except (json.JSONDecodeError, KeyError):
+    except (json.JSONDecodeError, KeyError) as exc:
+        logger.warning("Composer returned malformed JSON (%s); using fallback. Raw: %.200s", exc, raw)
         return _fallback_composition(description, orchestrator_result)
 
 

--- a/backend/services/agents/composer.py
+++ b/backend/services/agents/composer.py
@@ -12,7 +12,7 @@ import anthropic
 
 logger = logging.getLogger(__name__)
 
-_MODEL = "claude-sonnet-4-6"
+_MODEL = os.getenv("ANTHROPIC_MODEL", "claude-sonnet-4-6")
 
 _SYSTEM_PROMPT = """You are a master perfumer who writes the final fragrance formula and description.
 

--- a/backend/services/agents/orchestrator.py
+++ b/backend/services/agents/orchestrator.py
@@ -4,6 +4,7 @@ and prepare the context the Composition Agent needs.
 """
 from __future__ import annotations
 import json
+import logging
 import os
 
 import anthropic
@@ -11,6 +12,8 @@ import anthropic
 from services.tools.search_tool import search_fragrance_db
 from services.tools.note_profile_tool import get_note_profile
 from services.tools.validate_tool import validate_composition
+
+logger = logging.getLogger(__name__)
 
 _MODEL = "claude-sonnet-4-6"
 _MAX_TOOL_ROUNDS = 5
@@ -27,10 +30,6 @@ _TOOLS: list[dict] = [
             "type": "object",
             "properties": {
                 "query": {"type": "string", "description": "Descriptive search query"},
-                "scent_family": {
-                    "type": "string",
-                    "description": "Optional scent family filter (e.g. 'Woody', 'Floral')",
-                },
                 "top_k": {
                     "type": "integer",
                     "description": "Number of results to return (1–15)",
@@ -82,23 +81,18 @@ _SYSTEM_PROMPT = """You are a master perfumer's assistant with deep knowledge of
 Your job is to use the available tools to build rich, grounded context for creating a new fragrance composition from a user's description.
 
 Strategy:
-1. Search the fragrance database to find real-world reference fragrances semantically similar to the description.
-2. Use get_note_profile to understand the volatility and pairing properties of the most relevant notes from those references.
+1. Review the pre-loaded semantic search results provided in the user message.
+2. Use get_note_profile to understand the volatility and pairing properties of the most relevant notes.
 3. If the user has specified pinned notes, call get_note_profile on those as well.
-4. Think about what combination of notes best captures the user's description, informed by the references.
+4. Call search_fragrance_db only if you need more targeted references beyond the pre-loaded ones.
 5. Return a JSON summary of your findings in this exact structure:
 
 {
-  "reference_fragrances": [...],   // top references from search
+  "reference_fragrances": [...],
   "recommended_notes": {
     "top": ["note1", "note2"],
     "middle": ["note3", "note4"],
     "base": ["note5", "note6"]
-  },
-  "pinned_notes_placed": {         // where pinned notes were placed
-    "top": [],
-    "middle": [],
-    "base": []
   },
   "reasoning": "Brief explanation of why these notes fit the description"
 }
@@ -125,20 +119,30 @@ def run(context: dict) -> dict:
         detected_notes: list[str]
         predicted_family: str
         family_confidence: float
-        pinned_notes: list[str]  (optional)
+        pinned_notes: list[str]
+        initial_hits: list[dict]   pre-computed semantic search results
     """
     client = anthropic.Anthropic(api_key=os.environ.get("ANTHROPIC_API_KEY"))
 
     user_message = (
         f"Create a fragrance composition for this description:\n\n"
         f"\"{context['description']}\"\n\n"
-        f"NLP preprocessing has detected these notes explicitly mentioned: "
+        f"Detected notes (explicitly mentioned): "
         f"{context.get('detected_notes', []) or 'none'}\n"
         f"Predicted scent family: {context.get('predicted_family', 'unknown')} "
         f"(confidence: {context.get('family_confidence', 0):.0%})\n"
     )
     if context.get("pinned_notes"):
-        user_message += f"User has requested these notes must be included: {context['pinned_notes']}\n"
+        user_message += f"Required notes (user-pinned): {context['pinned_notes']}\n"
+
+    initial_hits = context.get("initial_hits", [])
+    if initial_hits:
+        user_message += (
+            f"\nPre-loaded semantic search results ({len(initial_hits)} references):\n"
+            f"{json.dumps(initial_hits[:5], indent=2)}\n\n"
+            f"Use these as your primary reference set. Call search_fragrance_db "
+            f"only if you need additional targeted results."
+        )
 
     messages = [{"role": "user", "content": user_message}]
 
@@ -154,11 +158,9 @@ def run(context: dict) -> dict:
         messages.append({"role": "assistant", "content": response.content})
 
         if response.stop_reason == "end_turn":
-            # Extract the final JSON summary from the last text block
             for block in reversed(response.content):
                 if hasattr(block, "text"):
                     text = block.text.strip()
-                    # Extract JSON if wrapped in markdown code fence
                     if "```" in text:
                         start = text.find("{")
                         end = text.rfind("}") + 1
@@ -170,10 +172,13 @@ def run(context: dict) -> dict:
                         return {"reasoning": text, "reference_fragrances": [], "recommended_notes": {}}
             return {}
 
+        if response.stop_reason == "max_tokens":
+            logger.warning("Orchestrator hit max_tokens limit before completing")
+            break
+
         if response.stop_reason != "tool_use":
             break
 
-        # Process tool calls
         tool_results = []
         for block in response.content:
             if block.type == "tool_use":

--- a/backend/services/agents/orchestrator.py
+++ b/backend/services/agents/orchestrator.py
@@ -15,7 +15,7 @@ from services.tools.validate_tool import validate_composition
 
 logger = logging.getLogger(__name__)
 
-_MODEL = "claude-sonnet-4-6"
+_MODEL = os.getenv("ANTHROPIC_MODEL", "claude-sonnet-4-6")
 _MAX_TOOL_ROUNDS = 5
 
 _TOOLS: list[dict] = [

--- a/backend/services/config.py
+++ b/backend/services/config.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+CANONICAL_FAMILIES: list[str] = [
+    "Floral",
+    "Oriental",
+    "Woody",
+    "Fresh/Citrus",
+    "Fougère",
+    "Chypre",
+    "Gourmand",
+    "Aquatic/Marine",
+    "Earthy/Mossy",
+]

--- a/backend/services/feedback.py
+++ b/backend/services/feedback.py
@@ -59,14 +59,19 @@ def save_feedback(
 def get_metrics() -> dict:
     engine = _get_engine()
     with engine.connect() as conn:
-        total = conn.execute(text("SELECT COUNT(*) FROM feedback")).scalar() or 0
-        avg_rating = conn.execute(text("SELECT AVG(rating) FROM feedback")).scalar()
-        distribution = {
-            str(i): conn.execute(
-                text("SELECT COUNT(*) FROM feedback WHERE rating = :r"), {"r": i}
-            ).scalar() or 0
-            for i in range(1, 6)
-        }
+        row = conn.execute(
+            text("SELECT COUNT(*), AVG(rating) FROM feedback")
+        ).one()
+        total, avg_rating = row[0] or 0, row[1]
+
+        dist_rows = conn.execute(
+            text("SELECT rating, COUNT(*) FROM feedback GROUP BY rating")
+        ).fetchall()
+
+    distribution = {str(i): 0 for i in range(1, 6)}
+    for rating, count in dist_rows:
+        distribution[str(rating)] = count
+
     return {
         "total_feedback": total,
         "average_rating": round(float(avg_rating), 2) if avg_rating else None,

--- a/backend/services/generate_fragrance.py
+++ b/backend/services/generate_fragrance.py
@@ -10,13 +10,10 @@ def generate_fragrance_from_description(
     context = preprocess(description)
     context["pinned_notes"] = pinned_notes or []
 
-    # Seed the orchestrator with top-k semantic matches upfront
-    initial_hits = search_fragrance_db(
-        query=description,
-        scent_family=context["predicted_family"] if context["family_confidence"] > 0.5 else None,
-        top_k=10,
-    )
-    context["initial_hits"] = initial_hits
+    # Seed the orchestrator with a broad semantic search upfront.
+    # The orchestrator receives these as pre-loaded context so it can skip
+    # its own initial search call and go straight to profiling notes.
+    context["initial_hits"] = search_fragrance_db(query=description, top_k=10)
 
     orchestrator_result = orchestrator.run(context)
     composition = composer.run(description, orchestrator_result)

--- a/backend/services/nlp/__init__.py
+++ b/backend/services/nlp/__init__.py
@@ -1,22 +1,11 @@
 from .note_extractor import NoteExtractor
 from .embedder import Embedder
 from .scent_classifier import ScentClassifier
+from services.config import CANONICAL_FAMILIES
 
 _note_extractor = NoteExtractor()
 _embedder = Embedder()
 _classifier = ScentClassifier()
-
-CANONICAL_FAMILIES = [
-    "Floral",
-    "Oriental",
-    "Woody",
-    "Fresh/Citrus",
-    "Fougère",
-    "Chypre",
-    "Gourmand",
-    "Aquatic/Marine",
-    "Earthy/Mossy",
-]
 
 
 def preprocess(description: str) -> dict:

--- a/backend/services/nlp/note_extractor.py
+++ b/backend/services/nlp/note_extractor.py
@@ -1,6 +1,9 @@
 import json
+import logging
 import os
 import spacy
+
+logger = logging.getLogger(__name__)
 
 _NOTES_PATH = os.path.join(os.path.dirname(__file__), "../../data/note_profiles.json")
 _FALLBACK_NOTES_PATH = os.path.join(
@@ -35,10 +38,11 @@ class NoteExtractor:
                     notes = ast.literal_eval(val)
                     if isinstance(notes, list):
                         notes_set.update(n.strip() for n in notes if n.strip())
-                except Exception:
+                except (ValueError, SyntaxError):
                     pass
             self.all_notes = sorted(notes_set)
         except Exception:
+            logger.warning("Failed to load notes from dataset; NER will be disabled", exc_info=True)
             self.all_notes = []
 
     def _build_ruler(self):

--- a/backend/services/nlp/scent_classifier.py
+++ b/backend/services/nlp/scent_classifier.py
@@ -33,7 +33,7 @@ CANONICAL_FAMILIES = sorted(set(_CONCEPT_MAP.values()))
 def _concepts_to_family(concepts_raw: str) -> str | None:
     try:
         concepts = ast.literal_eval(concepts_raw)
-    except Exception:
+    except (ValueError, SyntaxError):
         return None
     for concept in concepts:
         if concept in _CONCEPT_MAP:

--- a/backend/services/tools/search_tool.py
+++ b/backend/services/tools/search_tool.py
@@ -25,7 +25,7 @@ def _get_collection():
 
 def search_fragrance_db(
     query: str,
-    scent_family: str | None = None,
+    scent_family: str | None = None,  # kept for API compatibility; semantic search handles family naturally
     top_k: int = 10,
 ) -> list[dict]:
     collection = _get_collection()
@@ -34,14 +34,9 @@ def search_fragrance_db(
 
     query_vector = _embedder.encode(query)
 
-    where: dict | None = None
-    if scent_family:
-        where = {"scent_family": {"$eq": scent_family}}
-
     results = collection.query(
         query_embeddings=[query_vector],
         n_results=min(top_k, collection.count()),
-        where=where,
         include=["metadatas", "distances"],
     )
 

--- a/backend/services/tools/search_tool.py
+++ b/backend/services/tools/search_tool.py
@@ -23,11 +23,7 @@ def _get_collection():
     return _collection
 
 
-def search_fragrance_db(
-    query: str,
-    scent_family: str | None = None,  # kept for API compatibility; semantic search handles family naturally
-    top_k: int = 10,
-) -> list[dict]:
+def search_fragrance_db(query: str, top_k: int = 10) -> list[dict]:
     collection = _get_collection()
     if collection.count() == 0:
         return []

--- a/backend/services/tools/validate_tool.py
+++ b/backend/services/tools/validate_tool.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
-_VALID_FAMILIES = {
-    "Floral", "Oriental", "Woody", "Fresh/Citrus",
-    "Fougère", "Chypre", "Gourmand", "Aquatic/Marine", "Earthy/Mossy",
-}
+from services.config import CANONICAL_FAMILIES
+
+_VALID_FAMILIES = set(CANONICAL_FAMILIES)
 
 _MAX_NOTES_PER_TIER = 6
 _MIN_NOTES_PER_TIER = 1

--- a/backend/start.sh
+++ b/backend/start.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+CHROMA_DIR="${CHROMA_PERSIST_DIR:-/data/chroma_db}"
+
+if [ ! -d "$CHROMA_DIR" ] || [ -z "$(ls -A "$CHROMA_DIR" 2>/dev/null)" ]; then
+    echo "ChromaDB not found at $CHROMA_DIR — running ingestion (first-start, ~8 min)…"
+    python scripts/ingest_dataset.py
+    echo "Ingestion complete."
+fi
+
+exec gunicorn -w 2 -b "0.0.0.0:${PORT:-7860}" \
+    --timeout 120 \
+    --access-logfile - \
+    app:app

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,102 @@
+"""
+conftest.py — session-level stubs and shared fixtures.
+
+sentence_transformers is stubbed in sys.modules at the very top so the
+Embedder singleton never tries to download or load model weights.
+All fixtures import app *inside* their context so module-level singletons
+are constructed while the patches are active.
+"""
+import sys
+
+import numpy as np
+from unittest.mock import MagicMock
+
+# ── Stub sentence_transformers before any app code can import it ──────────
+_st_model = MagicMock()
+_st_model.encode.return_value = np.zeros(384, dtype=np.float32)  # has .tolist()
+_st_module = MagicMock()
+_st_module.SentenceTransformer.return_value = _st_model
+sys.modules.setdefault("sentence_transformers", _st_module)
+# ─────────────────────────────────────────────────────────────────────────
+
+import pytest
+from unittest.mock import patch
+
+
+MOCK_COMPOSITION = {
+    "name": "Autumn Pine Accord",
+    "scent_family": "Woody",
+    "top_notes": [
+        {"note": "Petitgrain", "percentage": 15},
+        {"note": "Bergamot", "percentage": 10},
+    ],
+    "middle_notes": [
+        {"note": "Pine Needle", "percentage": 30},
+        {"note": "Clary Sage", "percentage": 15},
+    ],
+    "base_notes": [
+        {"note": "Cedarwood", "percentage": 20},
+        {"note": "Vetiver", "percentage": 10},
+    ],
+    "poetic_description": "An autumn walk through a pine forest after rain.",
+    "similar_fragrances": [
+        {"brand": "Test Brand", "name": "Forest Walk", "similarity_score": 0.88}
+    ],
+    "confidence_score": 0.92,
+}
+
+
+@pytest.fixture()
+def client():
+    """
+    Flask test client with every external dependency mocked:
+    - Claude API (anthropic)          – no outbound calls
+    - ChromaDB (_get_collection)      – returns deterministic fixture data
+    - NLP model loaders               – no filesystem / download
+    - Feedback store (save/metrics)   – in-memory, no SQLite writes
+    Rate limiting is disabled so tests don't interfere with each other.
+    """
+    with (
+        patch("services.nlp.note_extractor.NoteExtractor._load_notes"),
+        patch("services.nlp.note_extractor.NoteExtractor._build_ruler"),
+        patch("services.nlp.scent_classifier.ScentClassifier._load_or_train"),
+        patch("services.agents.orchestrator.anthropic"),
+        patch("services.agents.composer.anthropic"),
+        patch("services.tools.search_tool._get_collection") as mock_coll,
+        patch("services.generate_fragrance.orchestrator.run") as mock_orch,
+        patch("services.generate_fragrance.composer.run") as mock_comp,
+        patch("services.feedback.save_feedback"),
+        patch("services.feedback.get_metrics") as mock_metrics,
+    ):
+        mock_coll.return_value.count.return_value = 100
+        mock_coll.return_value.query.return_value = {
+            "metadatas": [[
+                {
+                    "brand": "TestBrand", "name": "TestFrag",
+                    "description": "a test fragrance", "notes_list": "[]",
+                    "concepts_list": "[]",
+                }
+            ]],
+            "distances": [[0.15]],
+        }
+        mock_orch.return_value = {
+            "reference_fragrances": [],
+            "recommended_notes": {},
+            "reasoning": "test",
+        }
+        mock_comp.return_value = MOCK_COMPOSITION
+        mock_metrics.return_value = {
+            "total_feedback": 5,
+            "average_rating": 4.2,
+            "rating_distribution": {"1": 0, "2": 0, "3": 1, "4": 2, "5": 2},
+        }
+
+        from app import app
+        from limiter import limiter as _limiter
+        app.config["TESTING"] = True
+        # Flask-Limiter 4.x caches self.enabled at init_app time, so we must
+        # set the attribute directly to disable rate limiting in tests.
+        _limiter.enabled = False
+        with app.test_client() as c:
+            yield c
+        _limiter.enabled = True

--- a/backend/tests/integration/test_generate_endpoint.py
+++ b/backend/tests/integration/test_generate_endpoint.py
@@ -1,44 +1,9 @@
 """
 Integration tests for the /api/v1/generate endpoint.
-Claude API and ChromaDB are mocked so tests run without external services.
+Claude API and ChromaDB are mocked by the shared `client` fixture in conftest.py.
 """
 import json
 import pytest
-from unittest.mock import patch, MagicMock
-
-
-_MOCK_COMPOSITION = {
-    "name": "Autumn Pine Accord",
-    "scent_family": "Woody",
-    "top_notes": [{"note": "Petitgrain", "percentage": 15}, {"note": "Bergamot", "percentage": 10}],
-    "middle_notes": [{"note": "Pine Needle", "percentage": 30}, {"note": "Clary Sage", "percentage": 15}],
-    "base_notes": [{"note": "Cedarwood", "percentage": 20}, {"note": "Vetiver", "percentage": 10}],
-    "poetic_description": "An autumn walk through a pine forest after rain.",
-    "similar_fragrances": [{"brand": "Test Brand", "name": "Forest Walk", "similarity_score": 0.88}],
-    "confidence_score": 0.92,
-}
-
-
-@pytest.fixture()
-def client():
-    with patch("services.agents.orchestrator.anthropic"), \
-         patch("services.agents.composer.anthropic"), \
-         patch("services.tools.search_tool._get_collection") as mock_coll, \
-         patch("services.nlp.scent_classifier.ScentClassifier._load_or_train"), \
-         patch("services.nlp.note_extractor.NoteExtractor._load_notes"), \
-         patch("services.nlp.note_extractor.NoteExtractor._build_ruler"):
-
-        mock_coll.return_value.count.return_value = 0
-        mock_coll.return_value.query.return_value = {"metadatas": [[]], "distances": [[]]}
-
-        with patch("services.generate_fragrance.orchestrator.run") as mock_orch, \
-             patch("services.generate_fragrance.composer.run") as mock_comp:
-            mock_orch.return_value = {"reference_fragrances": [], "recommended_notes": {}, "reasoning": "test"}
-            mock_comp.return_value = _MOCK_COMPOSITION
-
-            from app import app
-            app.config["TESTING"] = True
-            yield app.test_client()
 
 
 def test_generate_returns_200(client):
@@ -68,12 +33,10 @@ def test_generate_schema_compliance(client):
         content_type="application/json",
     )
     data = resp.get_json()
-    # Required keys
     for key in ("name", "scent_family", "top_notes", "middle_notes", "base_notes",
                 "poetic_description", "similar_fragrances", "confidence_score"):
         assert key in data, f"Missing key: {key}"
 
-    # Percentages sum to 100
     all_notes = data["top_notes"] + data["middle_notes"] + data["base_notes"]
     total = sum(n["percentage"] for n in all_notes)
     assert abs(total - 100) <= 1, f"Percentages sum to {total}"

--- a/backend/tests/integration/test_routes.py
+++ b/backend/tests/integration/test_routes.py
@@ -1,0 +1,265 @@
+"""
+Integration tests covering all /api/v1/* endpoints and input validation.
+All external dependencies (Claude API, ChromaDB, NLP models, SQLite) are
+mocked by the shared `client` fixture from conftest.py.
+"""
+import json
+import pytest
+
+
+# ── /health ───────────────────────────────────────────────────────────────
+
+def test_health_returns_ok(client):
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    assert resp.get_json()["status"] == "ok"
+
+
+# ── /api/v1/generate ─────────────────────────────────────────────────────
+
+def test_generate_returns_200_with_valid_input(client):
+    resp = client.post(
+        "/api/v1/generate",
+        data=json.dumps({"description": "autumn forest after rain"}),
+        content_type="application/json",
+    )
+    assert resp.status_code == 200
+
+
+def test_generate_returns_composition_keys(client):
+    resp = client.post(
+        "/api/v1/generate",
+        data=json.dumps({"description": "warm spicy amber"}),
+        content_type="application/json",
+    )
+    data = resp.get_json()
+    for key in ("name", "scent_family", "top_notes", "middle_notes", "base_notes",
+                "poetic_description", "similar_fragrances", "confidence_score"):
+        assert key in data, f"Missing key: {key}"
+
+
+def test_generate_percentages_sum_to_100(client):
+    resp = client.post(
+        "/api/v1/generate",
+        data=json.dumps({"description": "fresh citrus morning"}),
+        content_type="application/json",
+    )
+    data = resp.get_json()
+    all_notes = data["top_notes"] + data["middle_notes"] + data["base_notes"]
+    total = sum(n["percentage"] for n in all_notes)
+    assert abs(total - 100) <= 1
+
+
+def test_generate_missing_description_returns_400(client):
+    resp = client.post(
+        "/api/v1/generate",
+        data=json.dumps({}),
+        content_type="application/json",
+    )
+    assert resp.status_code == 400
+    assert "description" in resp.get_json()["error"]
+
+
+def test_generate_empty_description_returns_400(client):
+    resp = client.post(
+        "/api/v1/generate",
+        data=json.dumps({"description": "   "}),
+        content_type="application/json",
+    )
+    assert resp.status_code == 400
+
+
+def test_generate_description_too_long_returns_400(client):
+    resp = client.post(
+        "/api/v1/generate",
+        data=json.dumps({"description": "x" * 501}),
+        content_type="application/json",
+    )
+    assert resp.status_code == 400
+    assert "500" in resp.get_json()["error"]
+
+
+def test_generate_strips_control_characters(client):
+    """Control chars in description should be stripped, not rejected."""
+    resp = client.post(
+        "/api/v1/generate",
+        data=json.dumps({"description": "autumn\x00forest\x1bafter rain"}),
+        content_type="application/json",
+    )
+    assert resp.status_code == 200
+
+
+def test_generate_pinned_notes_not_a_list_returns_400(client):
+    resp = client.post(
+        "/api/v1/generate",
+        data=json.dumps({"description": "forest", "pinned_notes": "Rose"}),
+        content_type="application/json",
+    )
+    assert resp.status_code == 400
+    assert "array" in resp.get_json()["error"]
+
+
+def test_generate_too_many_pinned_notes_returns_400(client):
+    resp = client.post(
+        "/api/v1/generate",
+        data=json.dumps({"description": "forest", "pinned_notes": ["Note"] * 11}),
+        content_type="application/json",
+    )
+    assert resp.status_code == 400
+    assert "10" in resp.get_json()["error"]
+
+
+def test_generate_accepts_valid_pinned_notes(client):
+    resp = client.post(
+        "/api/v1/generate",
+        data=json.dumps({"description": "forest", "pinned_notes": ["Rose", "Oud"]}),
+        content_type="application/json",
+    )
+    assert resp.status_code == 200
+
+
+def test_generate_no_json_body_returns_400(client):
+    resp = client.post("/api/v1/generate", data="not json", content_type="text/plain")
+    assert resp.status_code == 400
+
+
+# ── /api/v1/feedback ─────────────────────────────────────────────────────
+
+def _feedback_payload(**overrides):
+    base = {
+        "session_id": "test-session",
+        "input_description": "forest rain",
+        "composition": {"name": "Test"},
+        "rating": 4,
+    }
+    base.update(overrides)
+    return base
+
+
+def test_feedback_returns_201(client):
+    resp = client.post(
+        "/api/v1/feedback",
+        data=json.dumps(_feedback_payload()),
+        content_type="application/json",
+    )
+    assert resp.status_code == 201
+    assert resp.get_json()["status"] == "ok"
+
+
+def test_feedback_missing_field_returns_400(client):
+    payload = _feedback_payload()
+    del payload["rating"]
+    resp = client.post(
+        "/api/v1/feedback",
+        data=json.dumps(payload),
+        content_type="application/json",
+    )
+    assert resp.status_code == 400
+
+
+def test_feedback_rating_out_of_range_returns_400(client):
+    resp = client.post(
+        "/api/v1/feedback",
+        data=json.dumps(_feedback_payload(rating=6)),
+        content_type="application/json",
+    )
+    assert resp.status_code == 400
+
+
+def test_feedback_rating_zero_returns_400(client):
+    resp = client.post(
+        "/api/v1/feedback",
+        data=json.dumps(_feedback_payload(rating=0)),
+        content_type="application/json",
+    )
+    assert resp.status_code == 400
+
+
+def test_feedback_non_integer_rating_returns_400(client):
+    resp = client.post(
+        "/api/v1/feedback",
+        data=json.dumps(_feedback_payload(rating=3.5)),
+        content_type="application/json",
+    )
+    assert resp.status_code == 400
+
+
+def test_feedback_with_comment_accepted(client):
+    resp = client.post(
+        "/api/v1/feedback",
+        data=json.dumps(_feedback_payload(comment="Lovely composition")),
+        content_type="application/json",
+    )
+    assert resp.status_code == 201
+
+
+# ── /api/v1/search ───────────────────────────────────────────────────────
+
+def test_search_returns_200_with_query(client):
+    resp = client.get("/api/v1/search?q=pine+forest")
+    assert resp.status_code == 200
+    assert isinstance(resp.get_json(), list)
+
+
+def test_search_missing_q_returns_400(client):
+    resp = client.get("/api/v1/search")
+    assert resp.status_code == 400
+    assert "q" in resp.get_json()["error"]
+
+
+def test_search_empty_q_returns_400(client):
+    resp = client.get("/api/v1/search?q=")
+    assert resp.status_code == 400
+
+
+def test_search_q_too_long_returns_400(client):
+    resp = client.get(f"/api/v1/search?q={'x' * 501}")
+    assert resp.status_code == 400
+
+
+def test_search_accepts_optional_family(client):
+    resp = client.get("/api/v1/search?q=rose&family=Floral")
+    assert resp.status_code == 200
+
+
+# ── /api/v1/notes ────────────────────────────────────────────────────────
+
+def test_notes_returns_list(client):
+    resp = client.get("/api/v1/notes")
+    assert resp.status_code == 200
+    assert isinstance(resp.get_json(), list)
+
+
+# ── /api/v1/families ─────────────────────────────────────────────────────
+
+def test_families_returns_list(client):
+    resp = client.get("/api/v1/families")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert isinstance(data, list)
+    assert len(data) > 0
+
+
+def test_families_contains_expected_values(client):
+    resp = client.get("/api/v1/families")
+    families = resp.get_json()
+    assert "Floral" in families
+    assert "Woody" in families
+
+
+# ── /api/v1/metrics ──────────────────────────────────────────────────────
+
+def test_metrics_returns_expected_shape(client):
+    resp = client.get("/api/v1/metrics")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert "total_feedback" in data
+    assert "average_rating" in data
+    assert "rating_distribution" in data
+
+
+def test_metrics_rating_distribution_has_all_keys(client):
+    resp = client.get("/api/v1/metrics")
+    dist = resp.get_json()["rating_distribution"]
+    for key in ("1", "2", "3", "4", "5"):
+        assert key in dist

--- a/backend/tests/unit/test_composer.py
+++ b/backend/tests/unit/test_composer.py
@@ -1,0 +1,90 @@
+"""
+Unit tests for the Composition Agent's pure-Python helpers.
+Claude API calls are not exercised here.
+"""
+import pytest
+from services.agents.composer import _normalise_percentages, _fallback_composition
+
+
+# ── _normalise_percentages ────────────────────────────────────────────────
+
+def _make_comp(top, mid, base):
+    return {
+        "top_notes": [{"note": "A", "percentage": top}],
+        "middle_notes": [{"note": "B", "percentage": mid}],
+        "base_notes": [{"note": "C", "percentage": base}],
+    }
+
+
+def test_normalise_exact_100_unchanged():
+    comp = _make_comp(20, 50, 30)
+    _normalise_percentages(comp)
+    total = sum(n["percentage"] for n in
+                comp["top_notes"] + comp["middle_notes"] + comp["base_notes"])
+    assert abs(total - 100) <= 0.1
+
+
+def test_normalise_scales_up_from_50():
+    comp = _make_comp(10, 25, 15)  # sums to 50
+    _normalise_percentages(comp)
+    total = sum(n["percentage"] for n in
+                comp["top_notes"] + comp["middle_notes"] + comp["base_notes"])
+    assert abs(total - 100) <= 0.1
+
+
+def test_normalise_scales_down_from_200():
+    comp = _make_comp(40, 100, 60)  # sums to 200
+    _normalise_percentages(comp)
+    total = sum(n["percentage"] for n in
+                comp["top_notes"] + comp["middle_notes"] + comp["base_notes"])
+    assert abs(total - 100) <= 0.1
+
+
+def test_normalise_skips_when_within_tolerance():
+    comp = _make_comp(20, 50, 30)  # exact 100 — no scaling needed
+    original_top = comp["top_notes"][0]["percentage"]
+    _normalise_percentages(comp)
+    assert comp["top_notes"][0]["percentage"] == original_top
+
+
+def test_normalise_zero_total_no_crash():
+    comp = _make_comp(0, 0, 0)
+    _normalise_percentages(comp)  # should not raise
+
+
+def test_normalise_empty_composition():
+    comp = {"top_notes": [], "middle_notes": [], "base_notes": []}
+    _normalise_percentages(comp)  # should not raise
+
+
+# ── _fallback_composition ─────────────────────────────────────────────────
+
+def test_fallback_has_required_keys():
+    result = _fallback_composition("pine forest", {})
+    for key in ("name", "scent_family", "top_notes", "middle_notes",
+                "base_notes", "poetic_description", "similar_fragrances", "confidence_score"):
+        assert key in result
+
+
+def test_fallback_percentages_sum_to_100():
+    result = _fallback_composition("desc", {})
+    total = sum(n["percentage"] for n in
+                result["top_notes"] + result["middle_notes"] + result["base_notes"])
+    assert abs(total - 100) <= 1
+
+
+def test_fallback_includes_reference_fragrances():
+    orch = {
+        "reference_fragrances": [
+            {"brand": "Jo Malone", "name": "Wood Sage", "similarity_score": 0.9},
+            {"brand": "Chanel", "name": "No.5", "similarity_score": 0.8},
+        ]
+    }
+    result = _fallback_composition("desc", orch)
+    assert len(result["similar_fragrances"]) == 2
+    assert result["similar_fragrances"][0]["brand"] == "Jo Malone"
+
+
+def test_fallback_description_in_poetic_text():
+    result = _fallback_composition("autumn leaves", {})
+    assert "autumn leaves" in result["poetic_description"]

--- a/backend/tests/unit/test_feedback.py
+++ b/backend/tests/unit/test_feedback.py
@@ -1,0 +1,71 @@
+"""
+Unit tests for the feedback persistence layer.
+
+Each test gets a fresh SQLite database in a temp directory so tests are
+fully isolated and don't touch the real data/feedback.db file.
+"""
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolated_db(tmp_path, monkeypatch):
+    """Point feedback module at a fresh temp SQLite for each test."""
+    db_path = tmp_path / "test_feedback.db"
+    monkeypatch.setattr("services.feedback._DB_URL", f"sqlite:///{db_path}")
+    monkeypatch.setattr("services.feedback._engine", None)
+
+
+def test_metrics_empty_database():
+    from services.feedback import get_metrics
+    metrics = get_metrics()
+    assert metrics["total_feedback"] == 0
+    assert metrics["average_rating"] is None
+    assert all(v == 0 for v in metrics["rating_distribution"].values())
+
+
+def test_save_and_count_feedback():
+    from services.feedback import save_feedback, get_metrics
+    save_feedback(
+        session_id="s1",
+        input_description="pine forest",
+        composition={"name": "Forest Accord"},
+        rating=4,
+        comment="Lovely",
+    )
+    metrics = get_metrics()
+    assert metrics["total_feedback"] == 1
+    assert metrics["average_rating"] == 4.0
+
+
+def test_average_rating_multiple_entries():
+    from services.feedback import save_feedback, get_metrics
+    for rating in [2, 4, 5]:
+        save_feedback("s1", "desc", {}, rating)
+    metrics = get_metrics()
+    assert metrics["total_feedback"] == 3
+    assert abs(metrics["average_rating"] - round((2 + 4 + 5) / 3, 2)) < 0.01
+
+
+def test_rating_distribution():
+    from services.feedback import save_feedback, get_metrics
+    for rating in [1, 3, 3, 5]:
+        save_feedback("s1", "desc", {}, rating)
+    dist = get_metrics()["rating_distribution"]
+    assert dist["1"] == 1
+    assert dist["2"] == 0
+    assert dist["3"] == 2
+    assert dist["4"] == 0
+    assert dist["5"] == 1
+
+
+def test_composition_serialised_as_json():
+    from services.feedback import save_feedback, get_metrics
+    save_feedback("s1", "desc", {"name": "Test", "notes": ["Rose"]}, rating=3)
+    # If composition serialisation fails, save_feedback raises; success = no error
+    assert get_metrics()["total_feedback"] == 1
+
+
+def test_empty_comment_is_optional():
+    from services.feedback import save_feedback, get_metrics
+    save_feedback("s1", "desc", {}, rating=5)  # no comment arg
+    assert get_metrics()["total_feedback"] == 1

--- a/backend/tests/unit/test_note_extractor.py
+++ b/backend/tests/unit/test_note_extractor.py
@@ -1,47 +1,74 @@
+"""
+Unit tests for NoteExtractor.
+
+The extractor is built directly with a fixed note list so no filesystem
+access or model downloads are needed.
+"""
+import spacy
 import pytest
-from unittest.mock import patch, MagicMock
+from services.nlp.note_extractor import NoteExtractor
 
 
-def _make_extractor_with_notes(notes):
-    """Build a NoteExtractor with a fixed notes list (no filesystem needed)."""
-    with patch("services.nlp.note_extractor.os.path.exists", return_value=False), \
-         patch("services.nlp.note_extractor.pd") as mock_pd:
-        mock_df = MagicMock()
-        mock_df.__len__.return_value = len(notes)
-        mock_df["Notes"].dropna.return_value = [str(notes)]
-        mock_pd.read_csv.return_value = mock_df
-
-        import ast
-        import importlib
-        import services.nlp.note_extractor as mod
-        importlib.reload(mod)
-
-        extractor = mod.NoteExtractor.__new__(mod.NoteExtractor)
-        extractor.all_notes = notes
-        import spacy
-        from spacy.pipeline import EntityRuler
-        extractor.nlp = spacy.blank("en")
-        ruler = extractor.nlp.add_pipe("entity_ruler")
-        patterns = [{"label": "FRAGRANCE_NOTE", "pattern": n} for n in notes]
-        patterns += [{"label": "FRAGRANCE_NOTE", "pattern": n.lower()} for n in notes if n != n.lower()]
-        ruler.add_patterns(patterns)
-        return extractor
+def _make_extractor(notes: list[str]) -> NoteExtractor:
+    """Construct an extractor with an explicit note list, bypassing file I/O."""
+    extractor = object.__new__(NoteExtractor)
+    extractor.all_notes = notes
+    extractor.nlp = spacy.blank("en")
+    ruler = extractor.nlp.add_pipe("entity_ruler")
+    patterns = [{"label": "FRAGRANCE_NOTE", "pattern": note} for note in notes]
+    patterns += [
+        {"label": "FRAGRANCE_NOTE", "pattern": note.lower()}
+        for note in notes
+        if note != note.lower()
+    ]
+    ruler.add_patterns(patterns)
+    return extractor
 
 
-def test_extracts_explicit_notes():
-    extractor = _make_extractor_with_notes(["Bergamot", "Sandalwood", "Oud"])
+def test_extracts_notes_from_text():
+    extractor = _make_extractor(["Bergamot", "Sandalwood", "Oud"])
     result = extractor.extract("I want something with sandalwood and bergamot")
-    assert "Sandalwood" in result or "sandalwood".title() in result
-    assert "Bergamot" in result or "bergamot".title() in result
+    assert "Sandalwood" in result
+    assert "Bergamot" in result
+
+
+def test_case_insensitive_detection():
+    extractor = _make_extractor(["Rose", "Jasmine"])
+    assert "Rose" in extractor.extract("rose petals everywhere")
+    assert "Jasmine" in extractor.extract("jasmine blossom")
 
 
 def test_no_false_positives():
-    extractor = _make_extractor_with_notes(["Bergamot", "Rose"])
+    extractor = _make_extractor(["Bergamot", "Rose"])
     result = extractor.extract("I like walking in the park on rainy days")
     assert result == []
 
 
 def test_deduplicates_notes():
-    extractor = _make_extractor_with_notes(["Rose"])
+    extractor = _make_extractor(["Rose"])
     result = extractor.extract("rose and rose again rose")
     assert result.count("Rose") == 1
+
+
+def test_empty_string_returns_empty():
+    extractor = _make_extractor(["Rose", "Oud"])
+    assert extractor.extract("") == []
+
+
+def test_multi_word_note():
+    extractor = _make_extractor(["Pink Pepper", "Tonka Bean"])
+    result = extractor.extract("hints of pink pepper and tonka bean")
+    assert "Pink Pepper" in result
+    assert "Tonka Bean" in result
+
+
+def test_note_not_in_list_ignored():
+    extractor = _make_extractor(["Rose"])
+    result = extractor.extract("bergamot and oud and musk")
+    assert result == []
+
+
+def test_returns_title_case_canonical():
+    extractor = _make_extractor(["Cedarwood"])
+    result = extractor.extract("cedarwood smoke")
+    assert result == ["Cedarwood"]

--- a/backend/tests/unit/test_note_profile_tool.py
+++ b/backend/tests/unit/test_note_profile_tool.py
@@ -1,0 +1,61 @@
+"""
+Unit tests for get_note_profile.
+"""
+import json
+import pytest
+from unittest.mock import patch
+
+
+_SAMPLE_PROFILES = {
+    "Bergamot": {"volatility": "top", "family": "Fresh/Citrus", "pairs_well_with": ["Lemon"]},
+    "Rose": {"volatility": "middle", "family": "Floral", "pairs_well_with": ["Jasmine"]},
+    "Musk": {"volatility": "base", "family": "Oriental", "pairs_well_with": ["Amber"]},
+}
+
+
+@pytest.fixture()
+def patched_profiles():
+    with patch("services.tools.note_profile_tool._profiles", _SAMPLE_PROFILES):
+        yield
+
+
+def test_exact_case_match(patched_profiles):
+    from services.tools.note_profile_tool import get_note_profile
+    result = get_note_profile(["Bergamot"])
+    assert result["Bergamot"]["volatility"] == "top"
+    assert result["Bergamot"]["family"] == "Fresh/Citrus"
+
+
+def test_title_case_fallback(patched_profiles):
+    from services.tools.note_profile_tool import get_note_profile
+    result = get_note_profile(["bergamot"])  # lowercase lookup
+    assert result["bergamot"]["volatility"] == "top"
+
+
+def test_multiple_notes(patched_profiles):
+    from services.tools.note_profile_tool import get_note_profile
+    result = get_note_profile(["Bergamot", "Rose", "Musk"])
+    assert len(result) == 3
+    assert result["Rose"]["volatility"] == "middle"
+    assert result["Musk"]["volatility"] == "base"
+
+
+def test_unknown_note_returns_middle_default(patched_profiles):
+    from services.tools.note_profile_tool import get_note_profile
+    result = get_note_profile(["UnknownIngredient"])
+    profile = result["UnknownIngredient"]
+    assert profile["volatility"] == "middle"
+    assert profile["family"] == "unknown"
+    assert profile["pairs_well_with"] == []
+
+
+def test_empty_profiles_falls_back_gracefully():
+    with patch("services.tools.note_profile_tool._profiles", {}):
+        from services.tools.note_profile_tool import get_note_profile
+        result = get_note_profile(["Bergamot"])
+        assert result["Bergamot"]["volatility"] == "middle"
+
+
+def test_empty_note_list(patched_profiles):
+    from services.tools.note_profile_tool import get_note_profile
+    assert get_note_profile([]) == {}

--- a/backend/tests/unit/test_scent_classifier.py
+++ b/backend/tests/unit/test_scent_classifier.py
@@ -1,0 +1,61 @@
+"""
+Unit tests for ScentClassifier.
+Only the no-model fallback and the concept mapping are exercised here —
+training is slow and requires a dataset file.
+"""
+import pytest
+from unittest.mock import patch
+from services.nlp.scent_classifier import _concepts_to_family, _DEFAULT_FAMILY
+
+
+# ── _concepts_to_family helper ────────────────────────────────────────────
+
+def test_known_concept_maps_correctly():
+    assert _concepts_to_family("['Floral', 'Rose']") == "Floral"
+
+
+def test_first_matching_concept_wins():
+    # "Woody" comes first and should win over "Floral"
+    assert _concepts_to_family("['Woody', 'Floral']") == "Woody"
+
+
+def test_unknown_concept_returns_none():
+    assert _concepts_to_family("['UnknownTag']") is None
+
+
+def test_malformed_string_returns_none():
+    assert _concepts_to_family("not a list") is None
+
+
+def test_empty_list_returns_none():
+    assert _concepts_to_family("[]") is None
+
+
+# ── ScentClassifier.predict fallback ─────────────────────────────────────
+
+def test_predict_returns_default_when_no_model():
+    with patch("services.nlp.scent_classifier.ScentClassifier._load_or_train"):
+        from services.nlp.scent_classifier import ScentClassifier
+        clf = ScentClassifier()
+        clf._pipeline = None  # force the "no model" branch
+        family, confidence = clf.predict("fresh morning citrus breeze")
+        assert family == _DEFAULT_FAMILY
+        assert confidence == 0.0
+
+
+def test_predict_uses_pipeline_when_available():
+    from unittest.mock import MagicMock
+    import numpy as np
+
+    mock_pipeline = MagicMock()
+    mock_pipeline.predict_proba.return_value = [np.array([0.1, 0.1, 0.8])]
+    mock_pipeline.classes_ = ["Floral", "Woody", "Fresh/Citrus"]
+
+    with patch("services.nlp.scent_classifier.ScentClassifier._load_or_train"):
+        from services.nlp.scent_classifier import ScentClassifier
+        clf = ScentClassifier()
+        clf._pipeline = mock_pipeline
+
+    family, confidence = clf.predict("crisp lemon morning")
+    assert family == "Fresh/Citrus"
+    assert abs(confidence - 0.8) < 0.01

--- a/backend/tests/unit/test_validate_tool.py
+++ b/backend/tests/unit/test_validate_tool.py
@@ -1,8 +1,8 @@
 import pytest
-from services.tools.validate_tool import validate_composition
+from services.tools.validate_tool import validate_composition, _VALID_FAMILIES
 
 
-def _make_composition(**overrides):
+def _comp(**overrides):
     base = {
         "name": "Test Accord",
         "scent_family": "Woody",
@@ -15,14 +15,62 @@ def _make_composition(**overrides):
     return base
 
 
+# ── Valid cases ───────────────────────────────────────────────────────────
+
 def test_valid_composition():
-    result = validate_composition(_make_composition())
+    result = validate_composition(_comp())
     assert result["valid"] is True
     assert result["errors"] == []
 
 
+@pytest.mark.parametrize("family", sorted(_VALID_FAMILIES))
+def test_all_canonical_families_are_valid(family):
+    result = validate_composition(_comp(scent_family=family))
+    assert result["valid"] is True
+
+
+def test_percentages_within_tolerance_99():
+    comp = _comp(
+        top_notes=[{"note": "Bergamot", "percentage": 20}],
+        middle_notes=[{"note": "Rose", "percentage": 50}],
+        base_notes=[{"note": "Cedarwood", "percentage": 29}],  # sums to 99
+    )
+    result = validate_composition(comp)
+    assert result["valid"] is True
+
+
+def test_percentages_within_tolerance_101():
+    comp = _comp(
+        top_notes=[{"note": "Bergamot", "percentage": 20}],
+        middle_notes=[{"note": "Rose", "percentage": 51}],
+        base_notes=[{"note": "Cedarwood", "percentage": 30}],  # sums to 101
+    )
+    result = validate_composition(comp)
+    assert result["valid"] is True
+
+
+def test_max_similar_fragrances_exactly_five():
+    comp = _comp(
+        similar_fragrances=[{"brand": "X", "name": str(i), "similarity_score": 0.9} for i in range(5)]
+    )
+    assert validate_composition(comp)["valid"] is True
+
+
+def test_tier_with_max_six_notes():
+    notes = [{"note": f"Note{i}", "percentage": 10} for i in range(6)]
+    comp = _comp(
+        top_notes=notes,
+        middle_notes=[{"note": "Rose", "percentage": 25}],
+        base_notes=[{"note": "Musk", "percentage": 15}],
+    )
+    # 60+25+15 = 100
+    assert validate_composition(comp)["valid"] is True
+
+
+# ── Invalid cases ─────────────────────────────────────────────────────────
+
 def test_percentages_not_summing_to_100():
-    comp = _make_composition(
+    comp = _comp(
         top_notes=[{"note": "Bergamot", "percentage": 10}],
         middle_notes=[{"note": "Rose", "percentage": 40}],
         base_notes=[{"note": "Cedarwood", "percentage": 20}],
@@ -33,14 +81,19 @@ def test_percentages_not_summing_to_100():
 
 
 def test_unknown_scent_family():
-    comp = _make_composition(scent_family="Imaginary")
-    result = validate_composition(comp)
+    result = validate_composition(_comp(scent_family="Imaginary"))
     assert result["valid"] is False
     assert any("Imaginary" in e for e in result["errors"])
 
 
+def test_empty_scent_family_is_valid():
+    # Empty string bypasses the family check (the field is optional)
+    result = validate_composition(_comp(scent_family=""))
+    assert result["valid"] is True
+
+
 def test_too_many_similar_fragrances():
-    comp = _make_composition(
+    comp = _comp(
         similar_fragrances=[{"brand": "X", "name": str(i), "similarity_score": 0.9} for i in range(6)]
     )
     result = validate_composition(comp)
@@ -50,3 +103,45 @@ def test_too_many_similar_fragrances():
 def test_empty_composition():
     result = validate_composition({})
     assert result["valid"] is False
+
+
+def test_tier_with_zero_notes_top():
+    comp = _comp(top_notes=[])
+    result = validate_composition(comp)
+    assert result["valid"] is False
+    assert any("top" in e for e in result["errors"])
+
+
+def test_tier_with_zero_notes_middle():
+    comp = _comp(middle_notes=[])
+    result = validate_composition(comp)
+    assert result["valid"] is False
+    assert any("middle" in e for e in result["errors"])
+
+
+def test_tier_with_zero_notes_base():
+    comp = _comp(base_notes=[])
+    result = validate_composition(comp)
+    assert result["valid"] is False
+    assert any("base" in e for e in result["errors"])
+
+
+def test_tier_with_seven_notes():
+    seven_notes = [{"note": f"Note{i}", "percentage": 10} for i in range(7)]
+    comp = _comp(top_notes=seven_notes, middle_notes=[], base_notes=[])
+    result = validate_composition(comp)
+    assert result["valid"] is False
+    assert any("7 notes" in e for e in result["errors"])
+
+
+def test_multiple_errors_reported():
+    # Both bad family AND bad percentages
+    comp = _comp(
+        scent_family="Imaginary",
+        top_notes=[{"note": "X", "percentage": 10}],
+        middle_notes=[],
+        base_notes=[],
+    )
+    result = validate_composition(comp)
+    assert result["valid"] is False
+    assert len(result["errors"]) >= 2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,16 +2,19 @@ version: "3.8"
 services:
   backend:
     image: ghcr.io/ksek87/sniff_ai/backend:latest
-    build: ./backend
+    build:
+      context: .
+      dockerfile: backend/Dockerfile
     ports:
       - "5000:5000"
     environment:
+      - PORT=5000
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
       - CHROMA_PERSIST_DIR=/app/chroma_db
-      - FLASK_ENV=${FLASK_ENV}
+      - FLASK_ENV=${FLASK_ENV:-development}
     volumes:
       - ./backend:/app
-      - ./data_collection:/app/data_collection:ro
+      - ./data_collection:/data_collection:ro
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:5000/health"]
       interval: 30s

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+testpaths = backend/tests
+pythonpath = backend
+addopts = --tb=short -q


### PR DESCRIPTION
## Summary

The agentic Claude API pipeline (merged in #52) is far lighter than the old GPT-2 approach — only ~500MB RAM total. This PR wires up a real end-to-end deployment so the live site actually works.

**Current problem:** The GitHub Pages frontend calls `REACT_APP_API_URL` which defaults to `localhost:5000`. There is no deployed backend. The live site is non-functional.

**After this PR:**
- Backend self-initialises ChromaDB on first start and serves via gunicorn
- Docker image is built from repo root so `data_collection/dataset.csv` is bundled
- Frontend deploy workflow sets `REACT_APP_API_URL` from a `BACKEND_URL` GitHub secret
- `deploy.yml` is cleaned up (Node 16 → 18, removes package.json corruption, uses `npm ci`)

## Changes

### `backend/start.sh` (new)
Self-initialising startup script: checks `CHROMA_PERSIST_DIR`, runs `ingest_dataset.py` if ChromaDB is empty (~8 min on first deploy, then skipped), then execs gunicorn. No manual one-time step needed after deployment.

### `backend/Dockerfile`
- Build context is now repo root (`.`) so `data_collection/dataset.csv` can be `COPY`'d into the image at `/data_collection/dataset.csv` — matching the path the ingest script computes at runtime
- Starts gunicorn via `start.sh`; exposes port 7860 (HF Spaces default)

### `backend/requirements.txt`
Added `gunicorn>=21.0.0`.

### `backend/app.py`
- Removed `debug=True`
- CORS origins now env-configurable via `CORS_ORIGINS` (comma-separated)
- Port from `PORT` env var (defaults 7860)

### `.github/workflows/docker.yml`
Backend build now uses root context: `docker build -f backend/Dockerfile .`

### `.github/workflows/deploy.yml` (rewrite)
- Node 16 → 18; `actions/checkout` + `setup-node` → v4
- `npm install` → `npm ci` (reproducible)
- Removed `echo '...' >> package.json` (was corrupting the file)
- Removed redundant `npm install react@18 typescript` (already in package.json)
- Added `REACT_APP_API_URL: ${{ secrets.BACKEND_URL }}` — the critical missing link

### `docker-compose.yml`
- Build context updated to root; `PORT=5000` for local dev
- `data_collection` volume path corrected to `/data_collection:ro`

### `.dockerignore` (new)
Excludes `node_modules`, `chroma_db`, `__pycache__`, `.env` from build context.

### `README.md`
Full rewrite: architecture diagram, tech stack table, local setup steps, deployment instructions (HF Spaces + `BACKEND_URL` secret), data layer description, phase tracker.

## Deployment steps (one-time, after merge)

1. Merge this PR → `docker.yml` builds & pushes `ghcr.io/ksek87/sniff_ai/backend:latest`
2. Create a Hugging Face Space (Docker SDK, public) at [huggingface.co/spaces](https://huggingface.co/spaces)
3. Set Space secrets: `ANTHROPIC_API_KEY`, `CHROMA_PERSIST_DIR=/data/chroma_db`
4. Deploy the GHCR image; first start auto-ingests (~8 min), then serves
5. Copy the Space URL → GitHub repo secret `BACKEND_URL`
6. Re-run the frontend deploy workflow — GitHub Pages frontend now calls the live backend

## Test plan

- [ ] `GET <space-url>/health` → `{"status": "ok"}`
- [ ] `POST <space-url>/api/v1/generate` `{"description": "autumn walk through a pine forest after rain"}` → valid `FragranceComposition` JSON with notes summing to 100%
- [ ] `https://ksek87.github.io/sniff_ai/` → Fragrance Card renders end-to-end

https://claude.ai/code/session_01H9qmM8i3hNKE8GHGHb56Ac

---
_Generated by [Claude Code](https://claude.ai/code/session_01H9qmM8i3hNKE8GHGHb56Ac)_