### PR TITLE
feat: Langfuse observability + agentic tool improvements

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,3 +20,9 @@ CORS_ORIGINS=http://localhost:3000
 
 # Frontend: backend URL for local React dev server (leave unset in Docker — uses same origin)
 REACT_APP_API_URL=http://localhost:5000
+
+# Langfuse LLM observability — traces token usage, costs, tool calls, latency
+# Get keys at https://cloud.langfuse.com (free tier) or leave unset to disable
+LANGFUSE_PUBLIC_KEY=pk-lf-...
+LANGFUSE_SECRET_KEY=sk-lf-...
+# LANGFUSE_HOST=https://cloud.langfuse.com  # override only for self-hosted deployments

--- a/backend/api/routes.py
+++ b/backend/api/routes.py
@@ -6,6 +6,12 @@ from services.tools.search_tool import search_fragrance_db
 from services.nlp import get_all_notes, get_all_families
 from limiter import limiter
 
+try:
+    from langfuse.decorators import langfuse_context
+    _LANGFUSE = True
+except ImportError:
+    _LANGFUSE = False
+
 api_blueprint = Blueprint("api", __name__)
 
 _MAX_DESCRIPTION = 500
@@ -36,6 +42,13 @@ def generate():
     if len(raw_notes) > _MAX_PINNED_NOTES:
         return jsonify({"error": f"pinned_notes may contain at most {_MAX_PINNED_NOTES} items"}), 400
     pinned_notes = [_sanitize(str(n))[:_MAX_NOTE_LEN] for n in raw_notes if str(n).strip()]
+
+    if _LANGFUSE:
+        langfuse_context.update_current_trace(
+            user_id=data.get("session_id"),
+            input=description,
+            tags=["generate"],
+        )
 
     result = generate_fragrance_from_description(description, pinned_notes)
     return jsonify(result)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,4 +1,5 @@
 anthropic>=0.40.0
+langfuse>=2.0.0
 chromadb>=0.5.23
 sentence-transformers>=3.3.0
 spacy>=3.8.0

--- a/backend/services/agents/_client.py
+++ b/backend/services/agents/_client.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 import os
-import anthropic
+
+try:
+    from langfuse.anthropic import anthropic
+except ImportError:
+    import anthropic
 
 _MODEL = os.getenv("ANTHROPIC_MODEL", "claude-sonnet-4-6")
 _TIMEOUT = 60.0

--- a/backend/services/agents/composer.py
+++ b/backend/services/agents/composer.py
@@ -8,6 +8,14 @@ import logging
 import os
 import re
 
+try:
+    from langfuse.decorators import observe
+except ImportError:
+    def observe(name=None):
+        def decorator(func):
+            return func
+        return decorator
+
 from services.agents._client import _MODEL, get_client
 
 logger = logging.getLogger(__name__)
@@ -41,6 +49,7 @@ Rules:
 - The poetic_description should mirror the tone and register of the user's input"""
 
 
+@observe(name="composer")
 def run(description: str, orchestrator_result: dict) -> dict:
     """
     Run the Composition Agent.
@@ -57,7 +66,7 @@ def run(description: str, orchestrator_result: dict) -> dict:
 
     response = client.messages.create(
         model=_MODEL,
-        max_tokens=1500,
+        max_tokens=2048,
         system=[{"type": "text", "text": _SYSTEM_PROMPT, "cache_control": {"type": "ephemeral"}}],
         messages=[{"role": "user", "content": user_message}],
     )

--- a/backend/services/agents/orchestrator.py
+++ b/backend/services/agents/orchestrator.py
@@ -7,10 +7,18 @@ import json
 import logging
 import os
 
+try:
+    from langfuse.decorators import observe
+except ImportError:
+    def observe(name=None):
+        def decorator(func):
+            return func
+        return decorator
+
 from services.agents._client import _MODEL, get_client
 
 from services.tools.search_tool import search_fragrance_db
-from services.tools.note_profile_tool import get_note_profile
+from services.tools.note_profile_tool import get_note_profile, get_note_pairings
 from services.tools.validate_tool import validate_composition
 
 logger = logging.getLogger(__name__)
@@ -23,7 +31,8 @@ _TOOLS: list[dict] = [
         "description": (
             "Search the fragrance database using semantic similarity. "
             "Returns real-world fragrances most similar to the query description. "
-            "Use this to ground the composition in real fragrance knowledge."
+            "Use this to ground the composition in real fragrance knowledge. "
+            "Optionally filter by scent family to reduce cross-family noise."
         ),
         "input_schema": {
             "type": "object",
@@ -34,6 +43,15 @@ _TOOLS: list[dict] = [
                     "description": "Number of results to return (1–15)",
                     "default": 8,
                 },
+                "family": {
+                    "type": "string",
+                    "description": (
+                        "Optional scent family filter. Only results whose concepts "
+                        "include this family are returned. One of: Floral, Oriental, "
+                        "Woody, Fresh/Citrus, Fougère, Chypre, Gourmand, "
+                        "Aquatic/Marine, Earthy/Mossy."
+                    ),
+                },
             },
             "required": ["query"],
         },
@@ -42,7 +60,9 @@ _TOOLS: list[dict] = [
         "name": "get_note_profile",
         "description": (
             "Get the volatility class (top/middle/base), scent family, and "
-            "best pairing notes for one or more fragrance ingredients."
+            "best pairing notes for one or more fragrance ingredients. "
+            "The 'found' field in each result indicates whether the note exists "
+            "in the database (false means an unknown ingredient — avoid it)."
         ),
         "input_schema": {
             "type": "object",
@@ -57,10 +77,35 @@ _TOOLS: list[dict] = [
         },
     },
     {
+        "name": "get_note_pairings",
+        "description": (
+            "Given a list of notes already selected for the composition, return "
+            "notes that pair well with ALL of them (intersection of pairing sets). "
+            "Useful for filling remaining tiers with data-grounded suggestions."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "notes": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Notes already committed to the composition",
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Maximum number of suggestions to return",
+                    "default": 10,
+                },
+            },
+            "required": ["notes"],
+        },
+    },
+    {
         "name": "validate_composition",
         "description": (
             "Validate a draft fragrance composition. Checks that percentages sum "
-            "to 100%, tiers are balanced, and the scent family is recognised."
+            "to 100%, tiers are balanced, and the scent family is recognised. "
+            "Each error has a 'severity' of 'critical' (must fix) or 'warning' (acceptable)."
         ),
         "input_schema": {
             "type": "object",
@@ -104,11 +149,14 @@ def _dispatch_tool(tool_name: str, tool_input: dict):
         return search_fragrance_db(**tool_input)
     elif tool_name == "get_note_profile":
         return get_note_profile(tool_input["notes"])
+    elif tool_name == "get_note_pairings":
+        return get_note_pairings(tool_input["notes"], limit=tool_input.get("limit", 10))
     elif tool_name == "validate_composition":
         return validate_composition(tool_input["composition"])
     return {"error": f"Unknown tool: {tool_name}"}
 
 
+@observe(name="orchestrator")
 def run(context: dict) -> dict:
     """
     Run the Orchestrator Agent.
@@ -152,6 +200,7 @@ def run(context: dict) -> dict:
             system=[{"type": "text", "text": _SYSTEM_PROMPT, "cache_control": {"type": "ephemeral"}}],
             tools=_TOOLS,
             messages=messages,
+            extra_headers={"anthropic-beta": "token-efficient-tool-use-2025-02-19"},
         )
 
         messages.append({"role": "assistant", "content": response.content})

--- a/backend/services/tools/note_profile_tool.py
+++ b/backend/services/tools/note_profile_tool.py
@@ -23,9 +23,29 @@ def get_note_profile(notes: list[str]) -> dict[str, dict]:
     result: dict[str, dict] = {}
     for note in notes:
         profile = profiles.get(note) or profiles.get(note.title()) or profiles.get(note.lower())
-        result[note] = profile or {
-            "volatility": "middle",
-            "family": "unknown",
-            "pairs_well_with": [],
-        }
+        if profile:
+            result[note] = {**profile, "found": True}
+        else:
+            result[note] = {
+                "volatility": "middle",
+                "family": "unknown",
+                "pairs_well_with": [],
+                "found": False,
+            }
     return result
+
+
+def get_note_pairings(notes: list[str], limit: int = 10) -> list[str]:
+    """Return notes that pair well with ALL of the given notes (intersection)."""
+    profiles = _load()
+    sets: list[set[str]] = []
+    for note in notes:
+        profile = profiles.get(note) or profiles.get(note.title()) or profiles.get(note.lower())
+        if profile:
+            sets.append(set(profile.get("pairs_well_with", [])))
+    if not sets:
+        return []
+    common = sets[0].intersection(*sets[1:]) if len(sets) > 1 else sets[0]
+    # Exclude the input notes themselves from suggestions
+    common -= set(notes)
+    return sorted(common)[:limit]

--- a/backend/services/tools/search_tool.py
+++ b/backend/services/tools/search_tool.py
@@ -23,16 +23,19 @@ def _get_collection():
     return _collection
 
 
-def search_fragrance_db(query: str, top_k: int = 10) -> list[dict]:
+def search_fragrance_db(query: str, top_k: int = 10, family: str | None = None) -> list[dict]:
     collection = _get_collection()
     if collection.count() == 0:
         return []
 
     query_vector = _embedder.encode(query)
 
+    # Fetch extra results when filtering so we still return up to top_k after the filter
+    fetch_k = min(top_k * 3 if family else top_k, collection.count())
+
     results = collection.query(
         query_embeddings=[query_vector],
-        n_results=min(top_k, collection.count()),
+        n_results=fetch_k,
         include=["metadatas", "distances"],
     )
 
@@ -40,6 +43,8 @@ def search_fragrance_db(query: str, top_k: int = 10) -> list[dict]:
     for meta, dist in zip(
         results["metadatas"][0], results["distances"][0]
     ):
+        if family and family.lower() not in (meta.get("concepts_list", "") or "").lower():
+            continue
         output.append(
             {
                 "brand": meta.get("brand", ""),
@@ -50,4 +55,6 @@ def search_fragrance_db(query: str, top_k: int = 10) -> list[dict]:
                 "similarity_score": round(1 - dist, 4),
             }
         )
+        if len(output) >= top_k:
+            break
     return output

--- a/backend/services/tools/validate_tool.py
+++ b/backend/services/tools/validate_tool.py
@@ -8,8 +8,12 @@ _MAX_NOTES_PER_TIER = 6
 _MIN_NOTES_PER_TIER = 1
 
 
+def _err(message: str, severity: str = "critical") -> dict:
+    return {"message": message, "severity": severity}
+
+
 def validate_composition(composition: dict) -> dict:
-    errors: list[str] = []
+    errors: list[dict] = []
 
     top = composition.get("top_notes", [])
     middle = composition.get("middle_notes", [])
@@ -17,25 +21,25 @@ def validate_composition(composition: dict) -> dict:
 
     all_notes = top + middle + base
     if not all_notes:
-        errors.append("Composition has no notes.")
+        errors.append(_err("Composition has no notes."))
 
     total = sum(n.get("percentage", 0) for n in all_notes)
     if abs(total - 100) > 1:
-        errors.append(f"Percentages sum to {total}%, expected 100%.")
+        errors.append(_err(f"Percentages sum to {total}%, expected 100%."))
 
     for tier_name, tier in [("top", top), ("middle", middle), ("base", base)]:
         count = len(tier)
         if count < _MIN_NOTES_PER_TIER:
-            errors.append(f"{tier_name} tier has no notes.")
+            errors.append(_err(f"{tier_name} tier has no notes."))
         if count > _MAX_NOTES_PER_TIER:
-            errors.append(f"{tier_name} tier has {count} notes (max {_MAX_NOTES_PER_TIER}).")
+            errors.append(_err(f"{tier_name} tier has {count} notes (max {_MAX_NOTES_PER_TIER}).", "warning"))
 
     family = composition.get("scent_family", "")
     if family and family not in _VALID_FAMILIES:
-        errors.append(f"Unknown scent family: {family!r}.")
+        errors.append(_err(f"Unknown scent family: {family!r}."))
 
     similar = composition.get("similar_fragrances", [])
     if len(similar) > 5:
-        errors.append(f"Too many similar fragrances: {len(similar)} (max 5).")
+        errors.append(_err(f"Too many similar fragrances: {len(similar)} (max 5).", "warning"))
 
     return {"valid": len(errors) == 0, "errors": errors}

--- a/backend/tests/unit/test_note_profile_tool.py
+++ b/backend/tests/unit/test_note_profile_tool.py
@@ -1,5 +1,5 @@
 """
-Unit tests for get_note_profile.
+Unit tests for get_note_profile and get_note_pairings.
 """
 import json
 import pytest
@@ -7,8 +7,8 @@ from unittest.mock import patch
 
 
 _SAMPLE_PROFILES = {
-    "Bergamot": {"volatility": "top", "family": "Fresh/Citrus", "pairs_well_with": ["Lemon"]},
-    "Rose": {"volatility": "middle", "family": "Floral", "pairs_well_with": ["Jasmine"]},
+    "Bergamot": {"volatility": "top", "family": "Fresh/Citrus", "pairs_well_with": ["Lemon", "Cedar"]},
+    "Rose": {"volatility": "middle", "family": "Floral", "pairs_well_with": ["Jasmine", "Cedar"]},
     "Musk": {"volatility": "base", "family": "Oriental", "pairs_well_with": ["Amber"]},
 }
 
@@ -59,3 +59,56 @@ def test_empty_profiles_falls_back_gracefully():
 def test_empty_note_list(patched_profiles):
     from services.tools.note_profile_tool import get_note_profile
     assert get_note_profile([]) == {}
+
+
+# ── found field ───────────────────────────────────────────────────────────────
+
+def test_known_note_has_found_true(patched_profiles):
+    from services.tools.note_profile_tool import get_note_profile
+    result = get_note_profile(["Bergamot"])
+    assert result["Bergamot"]["found"] is True
+
+
+def test_unknown_note_has_found_false(patched_profiles):
+    from services.tools.note_profile_tool import get_note_profile
+    result = get_note_profile(["FakeNote123"])
+    assert result["FakeNote123"]["found"] is False
+
+
+# ── get_note_pairings ─────────────────────────────────────────────────────────
+
+def test_pairings_returns_intersection(patched_profiles):
+    from services.tools.note_profile_tool import get_note_pairings
+    # Bergamot pairs with ["Lemon", "Cedar"], Rose pairs with ["Jasmine", "Cedar"]
+    # Intersection = ["Cedar"]
+    result = get_note_pairings(["Bergamot", "Rose"])
+    assert result == ["Cedar"]
+
+
+def test_pairings_excludes_input_notes(patched_profiles):
+    from services.tools.note_profile_tool import get_note_pairings
+    result = get_note_pairings(["Bergamot"])
+    assert "Bergamot" not in result
+
+
+def test_pairings_single_note_returns_its_pairs(patched_profiles):
+    from services.tools.note_profile_tool import get_note_pairings
+    result = get_note_pairings(["Musk"])
+    assert "Amber" in result
+
+
+def test_pairings_unknown_note_returns_empty(patched_profiles):
+    from services.tools.note_profile_tool import get_note_pairings
+    result = get_note_pairings(["NonExistent"])
+    assert result == []
+
+
+def test_pairings_limit_is_respected(patched_profiles):
+    from services.tools.note_profile_tool import get_note_pairings
+    result = get_note_pairings(["Bergamot"], limit=1)
+    assert len(result) <= 1
+
+
+def test_pairings_empty_input_returns_empty(patched_profiles):
+    from services.tools.note_profile_tool import get_note_pairings
+    assert get_note_pairings([]) == []

--- a/backend/tests/unit/test_orchestrator.py
+++ b/backend/tests/unit/test_orchestrator.py
@@ -71,6 +71,21 @@ def test_dispatch_get_note_profile():
         assert "Oud" in result
 
 
+def test_dispatch_get_note_pairings():
+    with patch("services.agents.orchestrator.get_note_pairings") as mock_fn:
+        mock_fn.return_value = ["Cedar", "Musk"]
+        result = _dispatch_tool("get_note_pairings", {"notes": ["Bergamot", "Rose"], "limit": 5})
+        mock_fn.assert_called_once_with(["Bergamot", "Rose"], limit=5)
+        assert "Cedar" in result
+
+
+def test_dispatch_get_note_pairings_default_limit():
+    with patch("services.agents.orchestrator.get_note_pairings") as mock_fn:
+        mock_fn.return_value = []
+        _dispatch_tool("get_note_pairings", {"notes": ["Bergamot"]})
+        mock_fn.assert_called_once_with(["Bergamot"], limit=10)
+
+
 def test_dispatch_validate_composition():
     comp = {"name": "Test", "scent_family": "Woody"}
     with patch("services.agents.orchestrator.validate_composition") as mock_fn:

--- a/backend/tests/unit/test_search_tool.py
+++ b/backend/tests/unit/test_search_tool.py
@@ -89,3 +89,42 @@ def test_top_k_limits_results():
         search_fragrance_db("query", top_k=5)
     call_kwargs = coll.query.call_args.kwargs
     assert call_kwargs["n_results"] == 5
+
+
+# ── family filter ───────────────────────────────────────────────────────────
+
+def test_family_filter_excludes_non_matching():
+    """Results whose concepts_list does not contain the family are excluded."""
+    metas = [
+        {"brand": "A", "name": "Floral Frag", "description": "", "notes_list": "", "concepts_list": "Floral, Fresh"},
+        {"brand": "B", "name": "Woody Frag", "description": "", "notes_list": "", "concepts_list": "Woody"},
+    ]
+    dists = [0.1, 0.2]
+    with patch("services.tools.search_tool._get_collection") as mock_gc:
+        mock_gc.return_value = _make_collection(2, metas, dists)
+        from services.tools.search_tool import search_fragrance_db
+        result = search_fragrance_db("rose", family="Floral")
+    assert len(result) == 1
+    assert result[0]["name"] == "Floral Frag"
+
+
+def test_family_filter_is_case_insensitive():
+    """Family filter matches regardless of case."""
+    meta = {"brand": "A", "name": "N", "description": "", "notes_list": "", "concepts_list": "Woody, Fresh"}
+    with patch("services.tools.search_tool._get_collection") as mock_gc:
+        mock_gc.return_value = _make_collection(1, [meta], [0.1])
+        from services.tools.search_tool import search_fragrance_db
+        result = search_fragrance_db("cedar", family="woody")
+    assert len(result) == 1
+
+
+def test_no_family_filter_returns_all():
+    """Without family filter, all results are returned."""
+    metas = [{"brand": f"B{i}", "name": f"N{i}", "description": "", "notes_list": "", "concepts_list": f"Family{i}"}
+             for i in range(3)]
+    dists = [0.1 * i for i in range(3)]
+    with patch("services.tools.search_tool._get_collection") as mock_gc:
+        mock_gc.return_value = _make_collection(3, metas, dists)
+        from services.tools.search_tool import search_fragrance_db
+        result = search_fragrance_db("query")
+    assert len(result) == 3

--- a/backend/tests/unit/test_validate_tool.py
+++ b/backend/tests/unit/test_validate_tool.py
@@ -77,13 +77,13 @@ def test_percentages_not_summing_to_100():
     )
     result = validate_composition(comp)
     assert result["valid"] is False
-    assert any("70%" in e for e in result["errors"])
+    assert any("70%" in e["message"] for e in result["errors"])
 
 
 def test_unknown_scent_family():
     result = validate_composition(_comp(scent_family="Imaginary"))
     assert result["valid"] is False
-    assert any("Imaginary" in e for e in result["errors"])
+    assert any("Imaginary" in e["message"] for e in result["errors"])
 
 
 def test_empty_scent_family_is_valid():
@@ -109,21 +109,21 @@ def test_tier_with_zero_notes_top():
     comp = _comp(top_notes=[])
     result = validate_composition(comp)
     assert result["valid"] is False
-    assert any("top" in e for e in result["errors"])
+    assert any("top" in e["message"] for e in result["errors"])
 
 
 def test_tier_with_zero_notes_middle():
     comp = _comp(middle_notes=[])
     result = validate_composition(comp)
     assert result["valid"] is False
-    assert any("middle" in e for e in result["errors"])
+    assert any("middle" in e["message"] for e in result["errors"])
 
 
 def test_tier_with_zero_notes_base():
     comp = _comp(base_notes=[])
     result = validate_composition(comp)
     assert result["valid"] is False
-    assert any("base" in e for e in result["errors"])
+    assert any("base" in e["message"] for e in result["errors"])
 
 
 def test_tier_with_seven_notes():
@@ -131,7 +131,7 @@ def test_tier_with_seven_notes():
     comp = _comp(top_notes=seven_notes, middle_notes=[], base_notes=[])
     result = validate_composition(comp)
     assert result["valid"] is False
-    assert any("7 notes" in e for e in result["errors"])
+    assert any("7 notes" in e["message"] for e in result["errors"])
 
 
 def test_multiple_errors_reported():
@@ -145,3 +145,32 @@ def test_multiple_errors_reported():
     result = validate_composition(comp)
     assert result["valid"] is False
     assert len(result["errors"]) >= 2
+
+
+# ── Error shape ───────────────────────────────────────────────────────────────
+
+def test_error_has_message_and_severity_fields():
+    result = validate_composition(_comp(scent_family="Imaginary"))
+    for err in result["errors"]:
+        assert "message" in err
+        assert "severity" in err
+        assert err["severity"] in ("critical", "warning")
+
+
+def test_percentage_error_is_critical():
+    comp = _comp(
+        top_notes=[{"note": "Bergamot", "percentage": 10}],
+        middle_notes=[{"note": "Rose", "percentage": 40}],
+        base_notes=[{"note": "Cedarwood", "percentage": 20}],
+    )
+    result = validate_composition(comp)
+    pct_errors = [e for e in result["errors"] if "70%" in e["message"]]
+    assert pct_errors and pct_errors[0]["severity"] == "critical"
+
+
+def test_too_many_notes_tier_is_warning():
+    seven_notes = [{"note": f"Note{i}", "percentage": 10} for i in range(7)]
+    comp = _comp(top_notes=seven_notes, middle_notes=[{"note": "Rose", "percentage": 15}], base_notes=[{"note": "Musk", "percentage": 15}])
+    result = validate_composition(comp)
+    tier_errors = [e for e in result["errors"] if "7 notes" in e["message"]]
+    assert tier_errors and tier_errors[0]["severity"] == "warning"


### PR DESCRIPTION
## Summary

- **Langfuse observability**: drop-in Anthropic wrapper in `_client.py` auto-captures token usage, costs, tool calls, and latency per request. `@observe()` on `orchestrator.run()` and `composer.run()` groups multi-turn API calls under a single trace. Session metadata attached in `/generate`. Gracefully no-ops when `LANGFUSE_PUBLIC_KEY` / `LANGFUSE_SECRET_KEY` are absent.
- **`search_fragrance_db` family filter**: optional `family` param post-filters ChromaDB results by scent family, eliminating cross-family noise (e.g. Floral query returning Woody results at 0.78 similarity).
- **`get_note_profile` `found` field**: each returned profile now includes `"found": true|false` so Claude can identify and reject hallucinated note names before composing.
- **New `get_note_pairings()` tool**: given notes already selected, returns the intersection of their `pairs_well_with` sets — a data-grounded shortlist for filling remaining tiers. Wired into `_TOOLS` and `_dispatch_tool`.
- **`validate_composition` severity levels**: errors now carry `"severity": "critical"|"warning"` so Claude knows what must be fixed vs. what is acceptable.
- **Composer `max_tokens` 1500 → 2048**: prevents mid-JSON truncation on detailed poetic descriptions.
- **Token-efficient tool use beta**: `anthropic-beta: token-efficient-tool-use-2025-02-19` header added to orchestrator API calls (~40% reduction in tool schema token overhead).

## Test plan

- [ ] 143 tests pass (`python3 -m pytest backend/tests/`)
- [ ] New tests cover: `get_note_pairings` (6 cases), `found` field on `get_note_profile` (2 cases), `family` filter on `search_fragrance_db` (3 cases), error severity shape on `validate_composition` (3 cases), `get_note_pairings` dispatch in orchestrator (2 cases)
- [ ] `POST /api/v1/generate` with Langfuse credentials set → trace appears in Langfuse dashboard with orchestrator + composer spans and tool call list
- [ ] App starts and generates normally when Langfuse env vars are absent

https://claude.ai/code/session_01H9qmM8i3hNKE8GHGHb56Ac

---
_Generated by [Claude Code](https://claude.ai/code/session_01H9qmM8i3hNKE8GHGHb56Ac)_