### PR TITLE
ci: add GitHub Pages frontend deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,55 @@
+name: Deploy Frontend to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'frontend/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: cd frontend && npm ci --legacy-peer-deps
+
+      - name: Build
+        env:
+          REACT_APP_API_URL: ${{ secrets.BACKEND_URL }}
+          PUBLIC_URL: /${{ github.event.repository.name }}
+        run: cd frontend && CI=false npm run build
+
+      - uses: actions/configure-pages@v4
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: frontend/build
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary

Creates `.github/workflows/deploy.yml` to build and deploy the React frontend to GitHub Pages whenever `frontend/` changes land on `main`.

- Node 18, `npm ci --legacy-peer-deps`
- Builds with `REACT_APP_API_URL=${{ secrets.BACKEND_URL }}` (your HF Space URL) so the frontend calls the live backend
- `PUBLIC_URL` set dynamically from the repo name for correct GitHub Pages subpath routing
- Uses modern GitHub Pages deploy actions (`configure-pages`, `upload-pages-artifact`, `deploy-pages`)
- Also triggerable manually via `workflow_dispatch`

## Before merging

Add `BACKEND_URL` as a GitHub Actions secret in repo **Settings → Secrets and variables → Actions**:

```
BACKEND_URL = https://ksek87-sniff-ai.hf.space
```

Then enable GitHub Pages in repo **Settings → Pages → Source: GitHub Actions**.

## Test plan

- [ ] Add `BACKEND_URL` secret
- [ ] Enable GitHub Pages source: GitHub Actions
- [ ] Merge PR → workflow runs → frontend deploys to `https://ksek87.github.io/sniff_ai/`
- [ ] Visit URL → app loads and generate request reaches HF Space backend

https://claude.ai/code/session_01H9qmM8i3hNKE8GHGHb56Ac

---
_Generated by [Claude Code](https://claude.ai/code/session_01H9qmM8i3hNKE8GHGHb56Ac)_