### PR TITLE
docs: add live app link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Sniff AI
 
+**[Try it live →](https://ksek87.github.io/sniff_ai/)**
+
 Sniff AI translates poetic, descriptive language into professional fragrance compositions — complete with a notes pyramid (top / middle / base with percentages), a custom name, and real-world reference fragrances.
 
 > *"A thunderstorm over a pine forest at dusk"* → **Twilight Pine Accord** — Woody Aromatic, top: Bergamot + Petitgrain, heart: Pine Needle + Clary Sage, base: Cedarwood + Musk


### PR DESCRIPTION
Adds a prominent **Try it live** link at the top of the README pointing to the deployed GitHub Pages app.

https://claude.ai/code/session_01H9qmM8i3hNKE8GHGHb56Ac

---
_Generated by [Claude Code](https://claude.ai/code/session_01H9qmM8i3hNKE8GHGHb56Ac)_