### PR TITLE
fix: pin ajv@^6 to resolve CRA build error in CI

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,9 @@
     "deploy": "gh-pages -d build"
   },
   "homepage": "https://ksek87.github.io/sniff_ai",
+  "overrides": {
+    "ajv": "^6.12.6"
+  },
   "browserslist": {
     "production": [">0.2%", "not dead", "not op_mini all"],
     "development": ["last 1 chrome version", "last 1 firefox version", "last 1 safari version"]


### PR DESCRIPTION
Fixes the CI build error:
```
Error: Cannot find module 'ajv/dist/compile/codegen'
```

`react-scripts 5` uses `ajv-keywords` which requires `ajv@^6`, but npm resolves `ajv@8`. Adding `"overrides": { "ajv": "^6.12.6" }` to `package.json` forces the correct version across the dependency tree.

https://claude.ai/code/session_01H9qmM8i3hNKE8GHGHb56Ac

---
_Generated by [Claude Code](https://claude.ai/code/session_01H9qmM8i3hNKE8GHGHb56Ac)_