### PR TITLE
fix: remove retired token-efficient-tool-use beta header

### DIFF
--- a/backend/services/agents/orchestrator.py
+++ b/backend/services/agents/orchestrator.py
@@ -200,7 +200,6 @@ def run(context: dict) -> dict:
             system=[{"type": "text", "text": _SYSTEM_PROMPT, "cache_control": {"type": "ephemeral"}}],
             tools=_TOOLS,
             messages=messages,
-            extra_headers={"anthropic-beta": "token-efficient-tool-use-2025-02-19"},
         )
 
         messages.append({"role": "assistant", "content": response.content})


### PR DESCRIPTION
## Summary

- The `token-efficient-tool-use-2025-02-19` Anthropic beta header has been retired. Every `POST /api/v1/generate` call was returning HTTP 500 because the API rejected the request with `400 invalid_request_error: Unexpected value(s) token-efficient-tool-use-2025-02-19`.
- Removed the `extra_headers` argument from `client.messages.create` in `backend/services/agents/orchestrator.py:203`.

## Test plan

- [ ] `POST /api/v1/generate` returns a valid fragrance suggestion instead of 500
- [ ] Backend Docker image rebuilds and deploys to Hugging Face Spaces
- [ ] No other callers reference the retired beta header (`grep -r "token-efficient-tool-use" backend/` is clean)

https://claude.ai/code/session_01U646Vk5WV3ELC2gWZHQBD3

---
_Generated by [Claude Code](https://claude.ai/code/session_01U646Vk5WV3ELC2gWZHQBD3)_