### PR TITLE
ci: restart HF Space automatically after Docker image push

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -33,7 +33,9 @@ jobs:
         context: .
         file: backend/Dockerfile
         push: true
-        tags: ghcr.io/ksek87/sniff_ai/backend:latest
+        tags: |
+          ghcr.io/ksek87/sniff_ai/backend:latest
+          ghcr.io/ksek87/sniff_ai/backend:${{ github.sha }}
         cache-from: type=gha
         cache-to: type=gha,mode=max
 
@@ -42,3 +44,4 @@ jobs:
         curl -sf -X POST \
           "https://huggingface.co/api/spaces/ksek87/sniff-ai/restart?factory=true" \
           -H "Authorization: Bearer ${{ secrets.HF_TOKEN }}"
+        echo "Deployed image: ghcr.io/ksek87/sniff_ai/backend:${{ github.sha }}"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -36,3 +36,9 @@ jobs:
         tags: ghcr.io/ksek87/sniff_ai/backend:latest
         cache-from: type=gha
         cache-to: type=gha,mode=max
+
+    - name: Restart Hugging Face Space
+      run: |
+        curl -sf -X POST \
+          "https://huggingface.co/api/spaces/ksek87/sniff-ai/restart?factory=true" \
+          -H "Authorization: Bearer ${{ secrets.HF_TOKEN }}"


### PR DESCRIPTION
## Problem

HF Spaces that use an external Docker image (`ghcr.io/...`) don't automatically pull a new image when the `:latest` tag is overwritten. The Space keeps running the old container indefinitely.

## Fix

After the image is pushed, call the HF Spaces factory-restart API so it pulls the new image and redeploys:

```
POST https://huggingface.co/api/spaces/ksek87/sniff-ai/restart?factory=true
```

`factory=true` forces a full rebuild from the new image rather than just a process restart.

## Required action before merging

Add `HF_TOKEN` as a GitHub Actions secret:
- **GitHub repo → Settings → Secrets and variables → Actions → New repository secret**
- Name: `HF_TOKEN`
- Value: a Hugging Face token with **write** access to the `ksek87/sniff-ai` Space (generate at https://huggingface.co/settings/tokens)

https://claude.ai/code/session_01U646Vk5WV3ELC2gWZHQBD3

---
_Generated by [Claude Code](https://claude.ai/code/session_01U646Vk5WV3ELC2gWZHQBD3)_