### PR TITLE
fix: backend logging, ChromaDB path mismatch, and gunicorn config

### DIFF
--- a/backend/api/routes.py
+++ b/backend/api/routes.py
@@ -1,3 +1,4 @@
+import logging
 import re
 from flask import Blueprint, request, jsonify
 from services.generate_fragrance import generate_fragrance_from_description
@@ -5,6 +6,8 @@ from services.feedback import save_feedback, get_metrics
 from services.tools.search_tool import search_fragrance_db
 from services.nlp import get_all_notes, get_all_families
 from limiter import limiter
+
+logger = logging.getLogger(__name__)
 
 try:
     from langfuse.decorators import langfuse_context
@@ -50,7 +53,11 @@ def generate():
             tags=["generate"],
         )
 
-    result = generate_fragrance_from_description(description, pinned_notes)
+    try:
+        result = generate_fragrance_from_description(description, pinned_notes)
+    except Exception:
+        logger.exception("Generation failed for description=%r", description)
+        return jsonify({"error": "Generation failed. Please try again."}), 500
     return jsonify(result)
 
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from flask import Flask, jsonify, send_from_directory
 from flask_cors import CORS
@@ -6,6 +7,12 @@ from api.routes import api_blueprint
 from limiter import limiter
 
 load_dotenv()
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    handlers=[logging.StreamHandler()],
+)
 
 app = Flask(__name__)
 

--- a/backend/services/tools/search_tool.py
+++ b/backend/services/tools/search_tool.py
@@ -4,7 +4,7 @@ import os
 import chromadb
 from services.nlp.embedder import Embedder
 
-_CHROMA_DIR = os.environ.get("CHROMA_PERSIST_DIR", "./chroma_db")
+_CHROMA_DIR = os.environ.get("CHROMA_PERSIST_DIR", "/data/chroma_db")
 _COLLECTION_NAME = "fragrances"
 
 _client: chromadb.PersistentClient | None = None

--- a/backend/start.sh
+++ b/backend/start.sh
@@ -10,6 +10,8 @@ if [ ! -d "$CHROMA_DIR" ] || [ -z "$(ls -A "$CHROMA_DIR" 2>/dev/null)" ]; then
 fi
 
 exec gunicorn -w 2 -b "0.0.0.0:${PORT:-7860}" \
-    --timeout 120 \
+    --timeout 300 \
     --access-logfile - \
+    --error-logfile - \
+    --log-level info \
     app:app

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -102,6 +102,64 @@ body {
   cursor: not-allowed;
 }
 
+/* Generation progress */
+.generation-progress {
+  padding: 16px 0 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.progress-stages {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.progress-stage {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  color: var(--color-border);
+  font-family: Arial, sans-serif;
+  font-size: 0.88rem;
+  transition: color 0.3s;
+}
+
+.progress-stage.done  { color: var(--color-accent); }
+.progress-stage.active { color: var(--color-text); }
+
+.stage-icon {
+  width: 18px;
+  text-align: center;
+  font-size: 0.9rem;
+  flex-shrink: 0;
+}
+
+.stage-spinner {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border: 2px solid var(--color-accent);
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+.progress-elapsed {
+  margin: 0;
+  font-family: Arial, sans-serif;
+  font-size: 0.78rem;
+  color: var(--color-muted);
+}
+
 /* Error */
 .error-message {
   background: #fff3f3;

--- a/frontend/src/components/DescriptionInput.tsx
+++ b/frontend/src/components/DescriptionInput.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import GenerationProgress from './GenerationProgress';
 
 interface Props {
   onGenerate: (description: string) => void;
@@ -32,8 +33,9 @@ const DescriptionInput: React.FC<Props> = ({ onGenerate, loading, additionalCont
         className="generate-btn"
         disabled={loading || !description.trim()}
       >
-        {loading ? 'Creating fragrance…' : 'Create Fragrance'}
+        {loading ? 'Creating…' : 'Create Fragrance'}
       </button>
+      {loading && <GenerationProgress />}
     </form>
   );
 };

--- a/frontend/src/components/GenerationProgress.tsx
+++ b/frontend/src/components/GenerationProgress.tsx
@@ -1,0 +1,45 @@
+import React, { useState, useEffect } from 'react';
+
+const STAGES = [
+  { label: 'Analyzing your description',     threshold: 0 },
+  { label: 'Searching the fragrance database', threshold: 2 },
+  { label: 'Consulting the perfumer',          threshold: 6 },
+  { label: 'Composing your fragrance',         threshold: 18 },
+];
+
+const GenerationProgress: React.FC = () => {
+  const [elapsed, setElapsed] = useState(0);
+
+  useEffect(() => {
+    const start = Date.now();
+    const id = setInterval(() => setElapsed(Math.floor((Date.now() - start) / 1000)), 500);
+    return () => clearInterval(id);
+  }, []);
+
+  const currentStage = STAGES.reduce(
+    (acc, s, i) => (elapsed >= s.threshold ? i : acc),
+    0
+  );
+
+  return (
+    <div className="generation-progress" role="status" aria-live="polite">
+      <ol className="progress-stages">
+        {STAGES.map((s, i) => {
+          const done   = i < currentStage;
+          const active = i === currentStage;
+          return (
+            <li key={s.label} className={`progress-stage${done ? ' done' : active ? ' active' : ''}`}>
+              <span className="stage-icon" aria-hidden="true">
+                {done ? '✓' : active ? <span className="stage-spinner" /> : '·'}
+              </span>
+              <span className="stage-label">{s.label}</span>
+            </li>
+          );
+        })}
+      </ol>
+      <p className="progress-elapsed">{elapsed}s</p>
+    </div>
+  );
+};
+
+export default GenerationProgress;


### PR DESCRIPTION
## Root causes

**1. ChromaDB path mismatch (likely cause of silent generation failures)**

`search_tool.py` defaulted to `./chroma_db` but `start.sh` defaulted to `/data/chroma_db`. If the `CHROMA_PERSIST_DIR` HF Space secret is not set, ingestion writes to `/data/chroma_db` but the app searches a completely empty `./chroma_db` — returning no fragrance results and producing garbage compositions. Fixed to `/data/chroma_db` in both places.

**2. No Python logging configured**

`app.py` never called `logging.basicConfig()`, so all `logger.*` calls from all backend modules had no handler and their output was silently dropped. Added `StreamHandler` to stdout so every log line is visible in the container.

**3. Generate route swallowed exceptions**

The route called `generate_fragrance_from_description` with no try/except, relying on Flask's default error handler. In some container/gunicorn configurations this doesn't produce a visible traceback. Added explicit `logger.exception` so failures always appear in logs.

**4. Gunicorn error logs not routed to stdout**

`--error-logfile` was not set, so gunicorn's own error output (worker crashes, timeouts) went to stderr only. Added `--error-logfile -` and `--log-level info`.

**5. Gunicorn worker timeout too short**

120s can be exhausted by the orchestrator's 5 Claude tool-use rounds under load. Raised to 300s.

## Test plan
- [ ] Merge triggers Docker build + HF Space factory reset
- [ ] Container logs show gunicorn startup lines and Python log output
- [ ] `POST /api/v1/generate` returns a fragrance composition
- [ ] On error, a full traceback appears in container stdout

https://claude.ai/code/session_01U646Vk5WV3ELC2gWZHQBD3

---
_Generated by [Claude Code](https://claude.ai/code/session_01U646Vk5WV3ELC2gWZHQBD3)_