### PR TITLE
Refactor: tighten error handling, remove per-request TOCTOU check, clean up progress component

### DIFF
--- a/backend/api/routes.py
+++ b/backend/api/routes.py
@@ -72,13 +72,17 @@ def feedback():
     if not isinstance(rating, int) or not (1 <= rating <= 5):
         return jsonify({"error": "rating must be an integer between 1 and 5"}), 400
 
-    save_feedback(
-        session_id=data["session_id"],
-        input_description=data["input_description"],
-        composition=data["composition"],
-        rating=rating,
-        comment=data.get("comment", ""),
-    )
+    try:
+        save_feedback(
+            session_id=data["session_id"],
+            input_description=data["input_description"],
+            composition=data["composition"],
+            rating=rating,
+            comment=data.get("comment", ""),
+        )
+    except Exception:
+        logger.exception("Feedback save failed for session=%r", data.get("session_id"))
+        return jsonify({"error": "Failed to save feedback. Please try again."}), 500
     return jsonify({"status": "ok"}), 201
 
 
@@ -90,7 +94,11 @@ def search():
         return jsonify({"error": "q parameter is required"}), 400
     if len(query) > _MAX_DESCRIPTION:
         return jsonify({"error": f"q must be {_MAX_DESCRIPTION} characters or fewer"}), 400
-    results = search_fragrance_db(query, top_k=10)
+    try:
+        results = search_fragrance_db(query, top_k=10)
+    except Exception:
+        logger.exception("Search failed for query=%r", query)
+        return jsonify({"error": "Search failed. Please try again."}), 500
     return jsonify(results)
 
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -3,6 +3,7 @@ import os
 from flask import Flask, jsonify, send_from_directory
 from flask_cors import CORS
 from dotenv import load_dotenv
+from werkzeug.exceptions import NotFound
 from api.routes import api_blueprint
 from limiter import limiter
 
@@ -29,16 +30,14 @@ def health():
 
 
 _FRONTEND_BUILD = os.path.join(os.path.dirname(__file__), "frontend/build")
+_HAS_FRONTEND = os.path.isdir(_FRONTEND_BUILD)
 
 
 @app.route("/", defaults={"path": ""})
 @app.route("/<path:path>")
 def serve_react(path):
-    if not os.path.isdir(_FRONTEND_BUILD):
+    if not _HAS_FRONTEND:
         return jsonify({"error": "frontend build not found"}), 404
-    # send_from_directory uses werkzeug safe_join, which blocks path traversal
-    # and raises NotFound for missing files — no manual os.path.join needed.
-    from werkzeug.exceptions import NotFound
     try:
         return send_from_directory(_FRONTEND_BUILD, path or "index.html")
     except NotFound:

--- a/backend/services/tools/search_tool.py
+++ b/backend/services/tools/search_tool.py
@@ -25,13 +25,12 @@ def _get_collection():
 
 def search_fragrance_db(query: str, top_k: int = 10, family: str | None = None) -> list[dict]:
     collection = _get_collection()
-    if collection.count() == 0:
+    count = collection.count()
+    if count == 0:
         return []
 
     query_vector = _embedder.encode(query)
-
-    # Fetch extra results when filtering so we still return up to top_k after the filter
-    fetch_k = min(top_k * 3 if family else top_k, collection.count())
+    fetch_k = min(top_k * 3 if family else top_k, count)
 
     results = collection.query(
         query_embeddings=[query_vector],

--- a/frontend/src/components/GenerationProgress.tsx
+++ b/frontend/src/components/GenerationProgress.tsx
@@ -1,11 +1,19 @@
 import React, { useState, useEffect } from 'react';
 
 const STAGES = [
-  { label: 'Analyzing your description',     threshold: 0 },
-  { label: 'Searching the fragrance database', threshold: 2 },
-  { label: 'Consulting the perfumer',          threshold: 6 },
-  { label: 'Composing your fragrance',         threshold: 18 },
+  { label: 'Analyzing your description',      seconds: 0 },
+  { label: 'Searching the fragrance database', seconds: 2 },
+  { label: 'Consulting the perfumer',          seconds: 6 },
+  { label: 'Composing your fragrance',         seconds: 18 },
 ];
+
+function activeStageIndex(elapsed: number): number {
+  let idx = 0;
+  for (let i = 0; i < STAGES.length; i++) {
+    if (elapsed >= STAGES[i].seconds) idx = i;
+  }
+  return idx;
+}
 
 const GenerationProgress: React.FC = () => {
   const [elapsed, setElapsed] = useState(0);
@@ -16,23 +24,23 @@ const GenerationProgress: React.FC = () => {
     return () => clearInterval(id);
   }, []);
 
-  const currentStage = STAGES.reduce(
-    (acc, s, i) => (elapsed >= s.threshold ? i : acc),
-    0
-  );
+  const activeIdx = activeStageIndex(elapsed);
 
   return (
     <div className="generation-progress" role="status" aria-live="polite">
       <ol className="progress-stages">
-        {STAGES.map((s, i) => {
-          const done   = i < currentStage;
-          const active = i === currentStage;
+        {STAGES.map((stage, i) => {
+          const done = i < activeIdx;
+          const active = i === activeIdx;
+          const className = ['progress-stage', done && 'done', active && 'active']
+            .filter(Boolean)
+            .join(' ');
           return (
-            <li key={s.label} className={`progress-stage${done ? ' done' : active ? ' active' : ''}`}>
+            <li key={stage.label} className={className}>
               <span className="stage-icon" aria-hidden="true">
                 {done ? '✓' : active ? <span className="stage-spinner" /> : '·'}
               </span>
-              <span className="stage-label">{s.label}</span>
+              <span className="stage-label">{stage.label}</span>
             </li>
           );
         })}


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **`app.py`**: Move `NotFound` import to top level; evaluate `_HAS_FRONTEND` once at startup instead of calling `os.path.isdir` on every request (TOCTOU anti-pattern)
- **`routes.py`**: Add `try/except` error handling to `/feedback` and `/search` routes, consistent with `/generate` — unhandled exceptions now log with context and return a clean 500
- **`search_tool.py`**: Call `collection.count()` once per search (stored in `count`) instead of twice — was being called for the empty-check and again inside `min()`
- **`GenerationProgress.tsx`**: Extract `activeStageIndex()` as a named, testable function; build `className` as a filtered array instead of a nested ternary inside a template literal; rename loop variable `s` → `stage` for clarity

## Test plan

- [ ] Backend starts without error; `/health` returns `{"status": "ok"}`
- [ ] `/api/v1/generate` returns a fragrance composition
- [ ] `/api/v1/search?q=rose` returns results
- [ ] `/api/v1/feedback` with valid payload returns 201
- [ ] Frontend build succeeds (`npm run build`)
- [ ] Progress indicator advances through stages during generation

https://claude.ai/code/session_01U646Vk5WV3ELC2gWZHQBD3
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01U646Vk5WV3ELC2gWZHQBD3)_