### PR TITLE
fix: enable SQLite WAL mode and busy timeout to fix share failures

### DIFF
--- a/backend/services/db.py
+++ b/backend/services/db.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
+import logging
 import os
 
-from sqlalchemy import create_engine, Engine
+from sqlalchemy import event, text, create_engine, Engine
+
+logger = logging.getLogger(__name__)
 
 _DB_PATH = os.path.join(os.path.dirname(__file__), "../data/feedback.db")
 _DB_URL = f"sqlite:///{_DB_PATH}"
@@ -13,5 +16,17 @@ def get_engine() -> Engine:
     global _engine
     if _engine is None:
         os.makedirs(os.path.dirname(_DB_PATH), exist_ok=True)
-        _engine = create_engine(_DB_URL, connect_args={"check_same_thread": False})
+        logger.info("SQLite database: %s", _DB_PATH)
+        engine = create_engine(_DB_URL, connect_args={"check_same_thread": False})
+
+        @event.listens_for(engine, "connect")
+        def _set_pragmas(dbapi_conn, _record):
+            cursor = dbapi_conn.cursor()
+            # WAL mode: readers don't block writers; one writer at a time queues
+            cursor.execute("PRAGMA journal_mode=WAL")
+            # 30 s busy timeout: retry on lock instead of immediately failing
+            cursor.execute("PRAGMA busy_timeout=30000")
+            cursor.close()
+
+        _engine = engine
     return _engine

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -71,8 +71,8 @@ def client():
         patch("services.generate_fragrance.composer.run") as mock_comp,
         patch("services.feedback.save_feedback"),
         patch("services.feedback.get_metrics") as mock_metrics,
-        patch("services.shares.save_share", return_value="a" * 32),
-        patch("services.shares.get_share") as mock_get_share,
+        patch("api.routes.save_share", return_value="a" * 32),
+        patch("api.routes.get_share") as mock_get_share,
     ):
         mock_coll.return_value.count.return_value = 100
         mock_coll.return_value.query.return_value = {


### PR DESCRIPTION
## Summary

- Enables WAL (Write-Ahead Log) journal mode on every new SQLite connection so readers don't block writers
- Sets a 30-second busy timeout so concurrent writers retry on lock rather than immediately failing with "database is locked"
- Both are applied via a SQLAlchemy `event.listens_for(engine, "connect")` listener, so every connection in every gunicorn worker gets the correct settings at connection time

## Root cause

The production backend runs 4 gunicorn workers, each a separate process. SQLite's default busy timeout is 0 ms — if two workers try to write simultaneously, the second immediately gets `OperationalError: database is locked`, which surfaced as a 500 error when saving a shared fragrance link.

## Test plan

- [ ] Save a shared fragrance link in production and confirm the URL resolves
- [ ] Confirm no "database is locked" errors in gunicorn logs under concurrent share saves

https://claude.ai/code/session_01U646Vk5WV3ELC2gWZHQBD3

---
_Generated by [Claude Code](https://claude.ai/code/session_01U646Vk5WV3ELC2gWZHQBD3)_